### PR TITLE
Admin to delete vendor engagement

### DIFF
--- a/app/blueprints/vendor_blueprint.py
+++ b/app/blueprints/vendor_blueprint.py
@@ -52,6 +52,11 @@ def create_engagement():
 def update_engagement(engagement_id):
 	return vendor_controller.update_vendor_engagement(engagement_id)
 
+@engagement_blueprint.route('/<int:engagement_id>', methods=['DELETE'])
+@Auth.has_permission('delete_engagement')
+def delete_engagement(engagement_id):
+	return vendor_controller.delete_engagement(engagement_id)
+
 
 '''VENDOR RATING'''
 @rating_blueprint.route('/vendor/<int:vendor_id>', methods=['GET'])

--- a/app/controllers/vendor_controller.py
+++ b/app/controllers/vendor_controller.py
@@ -133,8 +133,20 @@ class VendorController(BaseController):
 
 		return self.handle_response('Invalid or incorrect engagement_id provided', status_code=400)
 
-	def delete_vendor_engagement(self, vendor_id):
-		pass
+	def delete_engagement(self, engagement_id):
+		engagement = self.vendor_engagement_repo.get(engagement_id)
+		if engagement:
+			if engagement.is_deleted:
+				return self.handle_response('This engagement has already been deleted', status_code=400)
+
+			if any(not dependent.is_deleted for dependent in engagement.menus):
+				return self.handle_response('This engagement cannot be deleted because it has a child object', status_code=400)
+			updates = {}
+			updates['is_deleted'] = True
+
+			self.vendor_engagement_repo.update(engagement, **updates)
+			return self.handle_response('Engagement deleted', payload={"status": "success"})
+		return self.handle_response('Invalid or incorrect engagement_id provided', status_code=400)
 
 
 	''' VENDOR RATING '''

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -129,7 +129,7 @@ class Auth:
 				if not user_role:
 					return make_response(jsonify({'msg': 'Access Error - No Role Granted'})), 400
 
-				user_perms = permission_repo.filter_by(**{'role_id': user_role.id})
+				user_perms = permission_repo.filter_by(**{'role_id': user_role.role_id})
 				
 				perms = [perm.keyword for perm in user_perms.items]
 				if len(perms) == 0:


### PR DESCRIPTION
#### What does this PR do?
- Enable user with admin right to delete a vendor engagement
#### Description of Task to be completed?
- Include the endpoint to delete vendor engagement
- Update the blue_print
- With tests for the endpoints
#### How should this be manually tested?
- Clone the branch `ft-admin-delete-engagement`
- Checkout to the branch
- Run `pytest` to ensure the tests are passing
- Start the application
- Create samples of vendor-engagement in the database
- Send a `delete` request to the `http://localhost:5000/api/v1/engagement/1` with a role that has `delete_vendor` permission
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
￼
#### Questions:
N/A
