### PR TITLE
Create endpoints for managing access rights

### DIFF
--- a/app/blueprints/role_blueprint.py
+++ b/app/blueprints/role_blueprint.py
@@ -33,30 +33,45 @@ def delete_role(role_id):
 	return role_controller.delete_role(role_id)
 
 ''' USER ROLES '''
-@role_blueprint.route('/user/<int:user_id>', methods=['GET'])
+@role_blueprint.route('/user/<user_id>', methods=['GET'])
+@Auth.has_permission('view_user_roles')
 def get_user_role(user_id):
-	return role_controller.get_user_role(user_id)
+	return role_controller.get_user_roles(user_id)
 
 @role_blueprint.route('/user', methods=['POST'])
-@Security.validator(['role_id|required:int', 'user_id|requied:int'])
+@Security.validator(['role_id|required:int', 'user_id|required'])
+@Auth.has_permission('create_user_roles')
 def create_user_role():
 	return role_controller.create_user_role()
 
-@role_blueprint.route('/user/<int:user_id>', methods=['DELETE'])
-def delete_user_role(user_id):
-	return role_controller.delete_user_role(user_id)
+@role_blueprint.route('/user/<int:user_role_id>', methods=['DELETE'])
+@Auth.has_permission('delete_user_roles')
+def delete_user_role(user_role_id):
+	return role_controller.delete_user_role(user_role_id)
 
 ''' ROLE PERMISSIONS '''
 @role_blueprint.route('/permissions/<int:role_id>', methods=['GET'])
+@Auth.has_permission('view_permissions')
 def get_role_permissions(role_id):
 	return role_controller.get_role_permissions(role_id)
 
+@role_blueprint.route('/permissions', methods=['GET'])
+@Auth.has_permission('view_permissions')
+def get_all_permissions():
+	return role_controller.get_all_permissions()
+
 @role_blueprint.route('/permissions', methods=['POST'])
 @Security.validator(['role_id|required:int', 'name|required', 'keyword|required'])
+@Auth.has_permission('create_permissions')
 def create_role_permission():
 	return role_controller.create_role_permission()
 
+@role_blueprint.route('/permissions/<int:permission_id>', methods=['PUT', 'PATCH'])
+@Auth.has_permission('create_permissions')
+def update_permission(permission_id):
+	return role_controller.update_permission(permission_id)
+
 @role_blueprint.route('/permissions/<int:permission_id>', methods=['DELETE'])
+@Auth.has_permission('delete_permissions')
 def delete_role_permission(permission_id):
 	return role_controller.delete_role_permission(permission_id)
-

--- a/app/controllers/menu_controller.py
+++ b/app/controllers/menu_controller.py
@@ -62,7 +62,7 @@ class MenuController(BaseController):
 
 			return self.handle_response('OK', payload={'dateOfMeal': menu_date, 'mealPeriod': menu_period, 'menuList': menu_list})
 
-		return self.handle_response('Provide valid meal period and date')
+		return self.handle_response('Provide valid meal period and date', status_code=400)
 
 	def update_menu(self, menu_id):
 		date, meal_period, main_meal_id, allowed_side, allowed_protein, side_items, protein_items, vendor_engagement_id = self.request_params(

--- a/app/models/base_model.py
+++ b/app/models/base_model.py
@@ -26,7 +26,6 @@ class BaseModel(db.Model):
 		
 	def serialize(self):
 		s = {to_camel_case(column.name): getattr(self, column.name) for column in self.__table__.columns if column.name not in ['created_at', 'updated_at']}
-		s['timestamps'] = {'created_at': self.created_at, 'updated_at': self.updated_at, 'date_pretty_short': self.created_at.strftime('%b %d, %Y'),
-						   'date_pretty': self.created_at.strftime('%B %d, %Y')}
+		s['timestamps'] = {'created_at': self.created_at, 'updated_at': self.updated_at}
 		return s
 

--- a/tests/integration/endpoints/test_permission_endpoints.py
+++ b/tests/integration/endpoints/test_permission_endpoints.py
@@ -1,0 +1,162 @@
+import datetime
+from tests.base_test_case import BaseTestCase
+from app.repositories import PermissionRepo
+from factories import PermissionFactory, RoleFactory, UserRoleFactory
+
+class TestPermissionEndpoints(BaseTestCase):
+
+	def setUp(self):
+		self.BaseSetUp()
+
+	def test_create_permission_without_right_permission(self):
+		permission = PermissionFactory.build()
+		role = RoleFactory.create(name='admin')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='create_permissions', role_id=role.id)
+		UserRoleFactory.create(user_id=user_id, role_id=100)
+
+		data = {'name': permission.name, 'keyword': permission.keyword, 'role_id': role.id}
+		response = self.client().post(self.make_url('/roles/permissions'),
+			data=self.encode_to_json_string(data), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		
+		self.assert400(response)
+		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
+	
+	def test_create_permission_with_right_permission(self):
+		permission = PermissionFactory.build()
+		role = RoleFactory.create(name='admin')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='create_permissions', role_id=role.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role.id)
+
+		data = {'name': permission.name, 'keyword': permission.keyword, 'role_id': role.id}
+		response = self.client().post(self.make_url('/roles/permissions'),
+			data=self.encode_to_json_string(data), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+		
+		self.assert200(response)
+		self.assertJSONKeyPresent(response_json, 'payload')
+		self.assertEqual(payload['permission']['name'], permission.name)
+		self.assertEqual(payload['permission']['keyword'], permission.keyword)
+		
+	def test_list_permissions_without_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		for i in range(1,4):
+			permission_repo.new_permission(role1.id, f'name-{i}', f'keyword-{i}')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='view_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=100)
+		
+		response = self.client().get(self.make_url('/roles/permissions'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+		self.assert400(response)
+		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
+
+	def test_list_permissions_with_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		for i in range(1,4):
+			permission_repo.new_permission(role1.id, f'name-{i}', f'keyword-{i}')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='view_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+		
+		response = self.client().get(self.make_url('/roles/permissions'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+
+		self.assert200(response)
+		self.assertEqual(len(payload['permissions']), 4)
+		self.assertJSONKeysPresent(payload['permissions'][0], 'name', 'keyword', 'roleId')
+		
+	def test_update_permissions_without_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission = permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='create_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=100)
+		data = {'name': 'New name1'}
+		response = self.client().put(self.make_url('/roles/permissions/{}'.format(permission.id)), data=self.encode_to_json_string(data), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+		self.assert400(response)
+		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
+
+	def test_update_permissions_with_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission = permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='create_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+		data = {'name': 'New name1'}
+		response = self.client().put(self.make_url('/roles/permissions/{}'.format(permission.id)), data=self.encode_to_json_string(data), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+
+		self.assert200(response)
+		self.assertEqual(payload['permission']['name'], data['name'])
+
+	def test_update_with_wrong_permission_id(self):
+
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission = permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='create_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+		data = {'name': 'New name1'}
+		response = self.client().put(self.make_url('/roles/permissions/1000'), data=self.encode_to_json_string(data), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		self.assert400(response)
+		self.assertEqual(response_json['msg'], 'Invalid or incorrect permission id provided')
+
+	def test_delete_permission_endpoint_with_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission = permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='delete_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+
+		response = self.client().delete(self.make_url(f'/roles/permissions/{permission.id}'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+
+		self.assert200(response)
+		self.assertEqual(payload['status'], 'success')
+		self.assertEqual(response_json['msg'], 'permission deleted')
+
+	def test_delete_permission_endpoint_without_right_permission(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission = permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='delete_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=1000)
+
+		response = self.client().delete(self.make_url(f'/roles/permissions/{permission.id}'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		self.assert400(response)
+		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
+
+	def test_delete_permission_endpoint_with_wrong_permission_id(self):
+		permission_repo = PermissionRepo()
+		role1 = RoleFactory.create(name='admin')
+		permission_repo.new_permission(role1.id, 'name-1', 'keyword-1')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='delete_permissions', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+		response = self.client().delete(self.make_url(f'/roles/permissions/576'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+		self.assert404(response)
+		self.assertEqual(response_json['msg'], 'Invalid or incorrect permission id provided')

--- a/tests/integration/endpoints/test_role_endpoints.py
+++ b/tests/integration/endpoints/test_role_endpoints.py
@@ -7,7 +7,7 @@ class TestRoleEndpoints(BaseTestCase):
 
 	def setUp(self):
 		self.BaseSetUp()
-	
+
 	def test_create_role_endpoint(self):
 		role = RoleFactory.build()
 		role1 = RoleFactory.create(name='admin')
@@ -19,12 +19,12 @@ class TestRoleEndpoints(BaseTestCase):
 		response = self.client().post(self.make_url('/roles/'), data=self.encode_to_json_string(data), headers=self.headers())
 		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
 		payload = response_json['payload']
-		
+
 		self.assert200(response)
 		self.assertJSONKeyPresent(response_json, 'payload')
 		self.assertEqual(payload['role']['name'], role.name)
 		self.assertEqual(payload['role']['help'], role.help)
-		
+
 	def test_list_roles_endpoint(self):
 		
 		RoleFactory.create_batch(3)
@@ -32,7 +32,7 @@ class TestRoleEndpoints(BaseTestCase):
 		user_id = BaseTestCase.user_id()
 		permission = PermissionFactory.create(keyword='view_roles', role_id=role1.id)
 		user_role = UserRoleFactory.create(user_id=user_id, role_id=role1.id)
-		
+
 		response = self.client().get(self.make_url('/roles/'), headers=self.headers())
 		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
 		payload = response_json['payload']
@@ -40,7 +40,7 @@ class TestRoleEndpoints(BaseTestCase):
 		self.assert200(response)
 		self.assertEqual(len(payload['roles']), 4)
 		self.assertJSONKeysPresent(payload['roles'][0], 'name', 'help')
-		
+
 	def test_get_specific_role_enpoint(self):
 		role = RoleFactory.create()
 		role1 = RoleFactory.create(name='admin')
@@ -66,7 +66,8 @@ class TestRoleEndpoints(BaseTestCase):
 		permission = PermissionFactory.create(keyword='create_roles', role_id=role1.id)
 		user_role = UserRoleFactory.create(user_id=user_id, role_id=role1.id)
 		data = {'name': 'Super Admin'}
-		response = self.client().put(self.make_url('/roles/{}'.format(role.id)), data=self.encode_to_json_string(data), headers=self.headers())
+		response = self.client().put(self.make_url('/roles/{}'
+		.format(role.id)), data=self.encode_to_json_string(data), headers=self.headers())
 		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
 		payload = response_json['payload']
 
@@ -114,13 +115,14 @@ class TestRoleEndpoints(BaseTestCase):
 		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
 
 	def test_delete_role_endpoint_with_wrong_role_id(self):
-		role = RoleFactory.create()
 
 		role1 = RoleFactory.create(name='admin')
 		user_id = BaseTestCase.user_id()
-		permission = PermissionFactory.create(keyword='delete_roles', role_id=role1.id)
-		user_role = UserRoleFactory.create(user_id=user_id, role_id=role1.id)
+		PermissionFactory.create(keyword='delete_roles', name='delete_roles', role_id=role1.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role1.id)
 
-		response = self.client().delete(self.make_url(f'/vendors/-576A'), headers=self.headers())
+		response = self.client().delete(self.make_url(f'/roles/1576'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
 
 		self.assert404(response)
+		self.assertEqual(response_json['msg'], 'Invalid or incorrect role_id provided')


### PR DESCRIPTION
#### What does this PR do?
	add endpoints for managing access rights
#### Description of Task to be completed?
- Multiple permissions with the same name
- add get_all_permissions end point
- add update_permission end point
- add delete_permission endpoint
- fix the get_user_roles endpoint
- fix create_user_role avoid duplication
- fix create_user_role avoid non-existing roles
- Write tests for the endpoints
#### How should this be manually tested?
- Clone the branch `ft-user-roles-permission-endpoints`
- Checkout to the branch
- Start the application
- with postman test the affected endpoints
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
￼N/A
#### Questions:
N/A