### PR TITLE
working version of swagger documentation for create & update menu

### DIFF
--- a/app/blueprints/documentation/create_menu.yml
+++ b/app/blueprints/documentation/create_menu.yml
@@ -2,53 +2,173 @@ Create a Menu
 ---
 tags:
   - Admin menu
-produces:
+summary: Creates a new menu.
+consumes:
   - application/json
-  - application/xml
 parameters:
   - in: body
-    name: date
-    description: Date of Action
-    type: date
-    required: true
-  - in: body
-    name: mealPeriod
-    description: Period of the Meal
-    type: string
-    required: true
-  - in: body
-    name: mainMealId
-    description: main Id of the meal from meal item
-    type: integer
-    required: true
-  - in: body
-    name: allowedSide
-    description: Number of allowed Sides
-    type: integer
-    required: true
-  - in: body
-    name: allowedProtein
-    description: Number of allowed Protein
-    type: integer
-    required: true
-  - in: body
-    name: sideItems
-    description: List of integer Ids for side items from meal item
-    type: List
-    required: true
-  - in: body
-    name: proteinItems
-    description: List of Integer Ids for side items from meal item
-    type: List
-    required: true
-  - in: body
-    name: vendorEngagementId
-    description: Id of the Vendor's Engagement
-    type: integer
-    required: true
-
-responses:
-  200:
-    description: OK
+    name: menu
+    description: The menu to create
     schema:
-      type: string
+      type: object
+      required:
+        - date
+        - mainMailId
+        - mealPeriod
+        - allowedSide
+        - allowedProtein
+        - sideItems
+        - proteinItems
+        - vendorEngagementId
+      properties:
+        date:
+          type: string
+        mealPeriod:
+          type: string
+        mainMealId:
+          type: string
+        allowedSide:
+          type: integer
+        allowedProtein:
+          type: integer
+        sideItems:
+          type: array
+          items:
+            type: integer
+            enum: [1,2,3]
+        proteinItems:
+          type: array
+          items:
+            type: integer
+            enum: [1,2,3]
+        vendorEngagementId:
+          type: integer
+definitions:
+  MenuPayload:
+    type: object
+    properties:
+      msg:
+        type: string
+        default: Ok
+      payload:
+        type: object
+        properties:
+          menu:
+            type: object
+            properties:
+              allowedProtein:
+                type: integer
+              allowedSide:
+                type: integer
+              date:
+                type: string
+                format: date
+                example: 2018-10-22
+              id:
+                type: integer
+              isDeleted:
+                type: boolean
+              mainMeal:
+                type: object
+                properties:
+                  description:
+                    type: string
+                  id:
+                    type: integer
+                  image:
+                    type: string
+                  isDeleted:
+                    type: boolean
+                  mealType:
+                    type: string
+                  name:
+                    type: string
+                  timestamps:
+                    type: object
+                    properties:
+                      created_at:
+                        type: string
+                        format: date
+                        example: 2018-10-22
+                      updated_at:
+                        type: string
+                        format: date
+                        example: 2018-10-22
+              mainMealId:
+                type: integer
+              mealPeriod:
+                type: string
+              vendorEngagementId:
+                type: integer
+              timestamps:
+                type: object
+                properties:
+                  created_at:
+                    type: string
+                    format: date
+                    example: 2018-10-22
+                  updated_at:
+                    type: string
+                    format: date
+                    example: 2018-10-22
+              sideItems:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                    image:
+                      type: string
+                    isDeleted:
+                      type: boolean
+                    mealType:
+                      type: string
+                    name:
+                      type: string
+                    timestamps:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+                        updated_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+              proteinItems:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                    image:
+                      type: string
+                    isDeleted:
+                      type: boolean
+                    mealType:
+                      type: string
+                    name:
+                      type: string
+                    timestamps:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+                        updated_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+responses:
+  201:
+    description: Ok
+    schema:
+          $ref: '#/definitions/MenuPayload'

--- a/app/blueprints/documentation/update_menu.yml
+++ b/app/blueprints/documentation/update_menu.yml
@@ -1,29 +1,175 @@
-This is using docstrings for specifications.
+Update a selected Menu
 ---
 tags:
   - Admin menu
-produces:
+summary: Updates an existing menu.
+consumes:
   - application/json
-  - application/xml
 parameters:
-  - name: CreateModel
-    in: body
-    type: object
-    required: true
-
+  - in: body
+    name: menu-update
+    description: The menu to to update
+    schema:
+      type: object
+      required:
+        - date
+        - mainMailId
+        - mealPeriod
+        - allowedSide
+        - allowedProtein
+        - sideItems
+        - proteinItems
+        - vendorEngagementId
+      properties:
+        date:
+          type: string
+        mealPeriod:
+          type: string
+        mainMealId:
+          type: string
+        allowedSide:
+          type: integer
+        allowedProtein:
+          type: integer
+        sideItems:
+          type: array
+          items:
+            type: integer
+            enum: [1,2,3]
+        proteinItems:
+          type: array
+          items:
+            type: integer
+            enum: [1,2,3]
+        vendorEngagementId:
+          type: integer
 definitions:
-  CreateModel:
+  MenuPayload:
     type: object
     properties:
-      date:
+      msg:
         type: string
-        example: 2018-11-05
-  Color:
-    type: string
+        default: Ok
+      payload:
+        type: object
+        properties:
+          menu:
+            type: object
+            properties:
+              allowedProtein:
+                type: integer
+              allowedSide:
+                type: integer
+              date:
+                type: string
+                format: date
+                example: 2018-10-22
+              id:
+                type: integer
+              isDeleted:
+                type: boolean
+              mainMeal:
+                type: object
+                properties:
+                  description:
+                    type: string
+                  id:
+                    type: integer
+                  image:
+                    type: string
+                  isDeleted:
+                    type: boolean
+                  mealType:
+                    type: string
+                  name:
+                    type: string
+                  timestamps:
+                    type: object
+                    properties:
+                      created_at:
+                        type: string
+                        format: date
+                        example: 2018-10-22
+                      updated_at:
+                        type: string
+                        format: date
+                        example: 2018-10-22
+              mainMealId:
+                type: integer
+              mealPeriod:
+                type: string
+              vendorEngagementId:
+                type: integer
+              timestamps:
+                type: object
+                properties:
+                  created_at:
+                    type: string
+                    format: date
+                    example: 2018-10-22
+                  updated_at:
+                    type: string
+                    format: date
+                    example: 2018-10-22
+              sideItems:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                    image:
+                      type: string
+                    isDeleted:
+                      type: boolean
+                    mealType:
+                      type: string
+                    name:
+                      type: string
+                    timestamps:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+                        updated_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+              proteinItems:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                    image:
+                      type: string
+                    isDeleted:
+                      type: boolean
+                    mealType:
+                      type: string
+                    name:
+                      type: string
+                    timestamps:
+                      type: object
+                      properties:
+                        created_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+                        updated_at:
+                          type: string
+                          format: date
+                          example: 2018-10-22
+
 responses:
   200:
-    description: A list of colors (may be filtered by palette)
+    description: Ok
     schema:
-      $ref: '#/definitions/CreateModel'
-    examples:
-      rgb: ['red', 'green', 'blue']
+          $ref: '#/definitions/MenuPayload'

--- a/app/controllers/menu_controller.py
+++ b/app/controllers/menu_controller.py
@@ -26,7 +26,6 @@ class MenuController(BaseController):
 				'date', 'mealPeriod', 'mainMealId', 'allowedSide',
 				'allowedProtein', 'sideItems', 'proteinItems', 'vendorEngagementId'
 			)
-		print('YYYYYYYYYYYYYYYYYYYY', protein_items)
 
 		menu = self.menu_repo.new_menu(
 			date, meal_period, main_meal_id, allowed_side,


### PR DESCRIPTION
**What does this PR do?**

• Enable documentation of urls

**Description of Task  completed?**

• create menu and update menu documentation done


**How should this be manually tested?**

• Clone the branch `fx-menu-post-list-data`  
• Checkout to the branch  
• Run `python run.py runserver`
• browse `http://{server_name}/apidocs`
