### PR TITLE
#163782820 Fix creating vendor engagement

### DIFF
--- a/app/repositories/vendor_engagement_repo.py
+++ b/app/repositories/vendor_engagement_repo.py
@@ -25,4 +25,7 @@ class VendorEngagementRepo(BaseRepo):
 			VendorEngagement.is_deleted.is_(False)).paginate(error_out=False)
 
 	def get_existing_engagement(self, start_date):
-		return VendorEngagement.query.filter(VendorEngagement.end_date >= start_date).count()
+		return VendorEngagement.query.filter(
+			VendorEngagement.end_date >= start_date,
+			VendorEngagement.is_deleted.is_(False)
+		).count()

--- a/tests/unit/repositories/test_vendor_engagement_repo.py
+++ b/tests/unit/repositories/test_vendor_engagement_repo.py
@@ -19,4 +19,41 @@ class TestVendorEngagementRepo(BaseTestCase):
 		self.assertEqual(engagement.start_date, new_engagement.start_date)
 		self.assertEqual(engagement.end_date, new_engagement.end_date)
 
+	def test_get_existing_engagement_when_engagment_exists(self):
+		engagement = VendorEngagementFactory.build()
+		self.repo.new_vendor_engagement(engagement.vendor.id, engagement.start_date,
+														 engagement.location_id, engagement.end_date, 1, 1)
+
+		count = self.repo.get_existing_engagement(engagement.start_date)
+
+		self.assertEqual(count, 1)
+
+	def test_get_existing_engagement_when_engagment_does_not_exists(self):
+		engagement = VendorEngagementFactory.build()
+
+		count = self.repo.get_existing_engagement(engagement.start_date)
+
+		self.assertEqual(count, 0)
+
+	def test_get_engagement_by_date_when_engagment_does_exists(self):
+		engagement = VendorEngagementFactory.build()
+
+		new_engagement = self.repo.new_vendor_engagement(engagement.vendor.id, engagement.start_date,
+										engagement.location_id, engagement.end_date, 1, 1)
+
+		paginated_result = self.repo.get_engagement_by_date()
+
+		self.assertIsInstance(paginated_result.items[0], VendorEngagement)
+		self.assertEqual(paginated_result.items[0], new_engagement)
+
+	def test_new_vendor_engagement_raises_exception_with_invalid_date_format(self):
+		engagement = VendorEngagementFactory.build()
+
+		invalid_start_date = 'invalid date format'
+
+		with self.assertRaises(Exception) as e:
+			self.repo.new_vendor_engagement(engagement.vendor.id, invalid_start_date,
+														 engagement.location_id, engagement.end_date, 1, 1)
+
+
 		


### PR DESCRIPTION
**What does this PR do?**

- Create operations for vendor engagement

**Description of Task to be completed?**

- User can delete and re-create engagements for a given vendor

**How should this be manually tested?**

- Run python run.py runserver
- Create an engagement for a given vendor
- Delete the newly created engagement
- Try to re-create the deleted engagement. This should be successful

**Any background context you want to provide?**

- Previously, re-creating a deleted engagement would fail with a response
```
{ 
    "msg": "An engagement already exists for this period. Kindly disable engagement first."
}
```

**What are the relevant pivotal tracker stories?**

- [163782820](https://www.pivotaltracker.com/story/show/163782820)
 