### PR TITLE
#163790193 Fix running tests on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,26 +43,15 @@ jobs:
             . venv/bin/activate
             pip install -r requirements.txt
       - run:
-          name: run coverage
+          name: run test and coverage
           command: |
             . venv/bin/activate
-            coverage run --source app/ -m unittest discover -s tests/  && coverage report && coveralls
+            pytest && coverage report && coveralls
 
       - save_cache:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            pytest
 
       - store_artifacts:
           path: test-reports


### PR DESCRIPTION
**What does this PR do?**

- Update Circle CI's `config.yml` file to use `Pytest` instead of `Unitest` for running tests

**Description of Task to be completed?**

- Circle CI should use `Pytest` instead of `Unitest` for running tests

**How should this be manually tested?**

- None

**Any background context you want to provide?**

- Using Unitest to run tests does not allow some tests aspects to be initiated. This is fixed by using Pytest to run tests instead.

**What are the relevant pivotal tracker stories?**

- [163790193](https://www.pivotaltracker.com/story/show/163790193) 
