### PR TITLE
#163790193 Fix running tests on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: run test and coverage
           command: |
             . venv/bin/activate
-            pytest && coverage report && coveralls
+            pytest --cov=app/ && coverage report && coveralls
 
       - save_cache:
           paths:


### PR DESCRIPTION
*What does this PR do?**

- Update Circle CI's `config.yml` file to use `Pytest` instead of `Unitest` for running tests

**Description of Task to be completed?**

- Circle CI should use `Pytest` instead of `Unitest` for running tests

**How should this be manually tested?**

- None

**Any background context you want to provide?**

- Using Unitest to run tests does not allow some tests aspects to be initiated. This is fixed by using Pytest to run tests instead.

**What are the relevant pivotal tracker stories?**

- [163790193](https://www.pivotaltracker.com/story/show/163790193) 