### PR TITLE
fix available booking day

### DIFF
--- a/app/controllers/bot_controller.py
+++ b/app/controllers/bot_controller.py
@@ -508,7 +508,8 @@ class BotController(BaseController):
                     end_on = current_date + timedelta(days=6)
 
                 if current_date.strftime('%a') == 'Sun':
-                    start_on = current_date + timedelta(days=1)
+                    next_day = 1 if int(current_date.strftime('%H')) < 15 else 2
+                    start_on = current_date + timedelta(days=next_day)
                     end_on = current_date + timedelta(days=5)
 
         return tuple((start_on, end_on))


### PR DESCRIPTION
**What does this PR do?**
- Ensures that beyond 3pm on Sunday, it is not possible to place an order against the next day, using Slack.

**Description of Task to be completed?**
-modify the BotController so that the right days are available for meal booking.

**How should this be manually tested?**
- from slack, use the `aetest` command to place order. If you are doing that on Sunday, the next available day will be Tuesday.
**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**

