### PR TITLE
fix test-current-time-by-time-zone

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,7 +26,9 @@ class TestAuth(BaseTestCase):
     def test_current_time_by_time_zone_negative_timezone(self):
         resp = current_time_by_zone('-4')
 
-        self.assertEqual(resp.hour, datetime.utcnow().hour - 4)
+        raw_utc = datetime.utcnow().hour - 4
+        result = raw_utc if raw_utc < 24 else raw_utc + 24
+        self.assertEqual(resp.hour, result)
 
     def test_check_date_current_vs_date_for_invalid(self):
         d1 = datetime.strptime('2019-01-01', '%Y-%m-%d')


### PR DESCRIPTION
**What does this PR do?**
- ensure that that for current_time_by_time_zone function passes irrespective of the time of the day.

**Description of Task to be completed?**
-the test was earlier written but fails at a certain time window. This fix updates the test to be able to pass at all times.
**How should this be manually tested?**
- run `pytest` at any time between 12 midnight and 4 am to confirm there are no failures
**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**

