### PR TITLE
#163870674 - Fix sorting vendor engagements

### DIFF
--- a/app/controllers/vendor_engagement_controller.py
+++ b/app/controllers/vendor_engagement_controller.py
@@ -16,7 +16,10 @@ class VendorEngagementController(BaseController):
 	def list_vendor_engagements(self):
 		location = Auth.get_location()
 
-		engagements = self.vendor_engagement_repo.filter_by(is_deleted=False, location_id=location)
+		engagements = self.vendor_engagement_repo.filter_by_desc(
+			self.vendor_engagement_repo._model.start_date,
+			is_deleted=False, location_id=location
+		)
 
 		engagements_list = []
 		for e in engagements.items:

--- a/app/repositories/base_repo.py
+++ b/app/repositories/base_repo.py
@@ -1,3 +1,4 @@
+from sqlalchemy import desc, asc
 
 class BaseRepo:
 	
@@ -45,6 +46,16 @@ class BaseRepo:
 		"""Query and filter the data of the model."""
 		#return self._model.query.filter_by(is_deleted=False).paginate(**kwargs, error_out=False)
 		return self._model.query.filter_by(**kwargs).paginate(error_out=False)
+
+	def filter_by_desc(self, *args, **kwargs):
+		"""Query and filter the data of the model in descending order"""
+		return self._model.query.filter_by(**kwargs).order_by(desc(*args)) \
+			.paginate(error_out=False)
+
+	def filter_by_asc(self, *args, **kwargs):
+		"""Query and filter the data of the model in ascending order"""
+		return self._model.query.filter_by(**kwargs).order_by(asc(*args)) \
+			.paginate(error_out=False)
 
 	def get_unpaginated(self, **kwargs):
 		"""Query and filter the data of the model."""

--- a/tests/unit/repositories/test_base_repo.py
+++ b/tests/unit/repositories/test_base_repo.py
@@ -116,6 +116,30 @@ class TestBaseRepository(BaseTestCase):
 		self.assertEqual(paginated_result.items[0], vendor_1)
 		self.assertEqual(paginated_result.items[1], vendor_2)
 
+	def test_filter_by_asc_method_returns_ascending_ordered_results(self):
+		vendor_1 = VendorFactory.create()
+		vendor_2 = VendorFactory.create()
+
+		vendor_names = sorted([vendor.name for vendor in [vendor_1, vendor_2]])
+
+		results = self.repo.filter_by_asc(Vendor.name)
+
+		self.assertEqual(vendor_names[0], results.items[0].name)
+		self.assertEqual(vendor_names[1], results.items[1].name)
+
+	def test_filter_by_desc_method_returns_descending_ordered_results(self):
+		vendor_1 = VendorFactory.create()
+		vendor_2 = VendorFactory.create()
+
+		vendor_names = sorted(
+			[vendor.name for vendor in [vendor_1, vendor_2]],
+			reverse=True
+		)
+
+		results = self.repo.filter_by_desc(Vendor.name)
+		self.assertEqual(vendor_names[0], results.items[0].name)
+		self.assertEqual(vendor_names[1], results.items[1].name)
+
 
 
 


### PR DESCRIPTION
**What does this PR do?**
- Fixes issues with a get request on the endpoint `/api/v1/engagements/` not returning data sorted according to the `start_date`

**Description of Task to be completed?**
- Create two instance methods; one to return data for a model in ascending order and the other to return data in descending order.
- Refactor the list_vendor_engagement method of the VendorEngagementController class to extract engagements sorted in descending order of `start_date`
- Write tests for the newly added code.

**How should this be manually tested?**
- Pull this branch locally by running `git fetch bg-fix-engagement-sort-163870674`
- Create a vendor by performing a post on the endpoint `api/v1/vendors/`
- Create two engagements, of different dates, using this vendor by performing a post on the endpoint `api/v1/engagements/`
- Perform a get request on the endpoint `api/v1/engagements/` and you should be able to get results sorted according to their creation dates

**Any background context you want to provide?**
- Previously it was not possible to return data from the `api/v1/engagements/` sorted according to the `start date`. 

**What are the relevant pivotal tracker stories?**

- [#163870674](https://www.pivotaltracker.com/story/show/163870674)