### PR TITLE
fix slack booking cut off time

### DIFF
--- a/app/controllers/bot_controller.py
+++ b/app/controllers/bot_controller.py
@@ -441,18 +441,18 @@ class BotController(BaseController):
 
         current_date = current_time_by_zone(location.zone)
 
-        if current_date.strftime('%a') == 'Mon' and int(current_date.strftime('%H')) > 15:
+        if current_date.strftime('%a') == 'Mon' and int(current_date.strftime('%H')) >= 15:
             start_on = current_date + timedelta(days=2)
             end_on = start_on + timedelta(days=2)
 
-        elif current_date.strftime('%a') == 'Tue' and int(current_date.strftime('%H')) > 15:
+        elif current_date.strftime('%a') == 'Tue' and int(current_date.strftime('%H')) >= 15:
             start_on = current_date + timedelta(days=2)
             end_on = start_on + timedelta(days=1)
 
-        elif current_date.strftime('%a') == 'Wed' and int(current_date.strftime('%H')) > 15:
+        elif current_date.strftime('%a') == 'Wed' and int(current_date.strftime('%H')) >= 15:
             start_on = end_on = current_date + timedelta(days=2)
 
-        elif current_date.strftime('%a') == 'Thu' and int(current_date.strftime('%H')) > 15:
+        elif current_date.strftime('%a') == 'Thu' and int(current_date.strftime('%H')) >= 15:
             start_on = end_on = current_date + timedelta(days=4)
 
         else:

--- a/tests/integration/endpoints/test_bot_endpoints.py
+++ b/tests/integration/endpoints/test_bot_endpoints.py
@@ -39,7 +39,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_after_3pm_sunday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-10 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-10 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 
@@ -60,7 +60,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_after_3pm_monday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-11 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-11 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 
@@ -80,7 +80,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_after_3pm_tuesday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-12 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-12 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 
@@ -100,7 +100,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_after_3pm_wednesday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-13 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-13 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 
@@ -120,7 +120,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_after_3pm_thursday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-14 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-14 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 
@@ -140,7 +140,7 @@ class TestBotEndpoints(BaseTestCase):
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_saturday(self, mock_get):
-        mock_get.return_value = datetime.strptime('2019-02-16 16:01', '%Y-%m-%d %H:%M')
+        mock_get.return_value = datetime.strptime('2019-02-16 15:01', '%Y-%m-%d %H:%M')
 
         result = self.bot_controller.get_menu_start_end_on(LocationFactory.build())
 


### PR DESCRIPTION
**What does this PR do?**
- ensures that booking via slack has a cut off of 3 pm

**Description of Task to be completed?**
- fix the function that handles the checking
- add test to check it
**How should this be manually tested?**
- run `pytest`
**Any background context you want to provide?**
None

**What are the relevant pivotal tracker stories?**

