### PR TITLE
#163973598 - Increase slack helper utility test coverage

### DIFF
--- a/tests/unit/utils/test_slack_helper.py
+++ b/tests/unit/utils/test_slack_helper.py
@@ -1,0 +1,128 @@
+""" Unit tests for the app.utils.slackhelper.py
+"""
+from unittest.mock import patch
+
+from app.utils.slackhelper import SlackHelper
+from tests.base_test_case import BaseTestCase
+
+
+class TestSlackHelper(BaseTestCase):
+
+    def setUp(self):
+        self.BaseSetUp()
+
+    @patch('app.utils.slackhelper.SlackClient.api_call')
+    def test_post_message_works(
+        self,
+        mock_slack_api_call
+    ):
+        mock_slack_api_call.return_value = {
+            "ok": "true",
+            "channel": "Eat",
+            "message": "Hi"
+        }
+
+        slack_helper = SlackHelper()
+
+        assert slack_helper.post_message(msg="Hi", recipient="Roger").get("ok") == "true"
+        assert slack_helper.post_message(msg="Hi", recipient="Roger").get("channel") == "Eat"
+        assert slack_helper.post_message(msg="Hi", recipient="Roger").get("message") == "Hi"
+
+    @patch('app.utils.slackhelper.SlackClient.api_call')
+    def test_update_message_works(
+        self,
+        mock_slack_api_call
+    ):
+        mock_slack_api_call.return_value = {
+            "ok": "true",
+            "channel": "Eat",
+            "text": "Hi again"
+        }
+
+        slack_helper = SlackHelper()
+
+        assert slack_helper.update_message(msg="Hi", recipient="Roger").get("ok") == "true"
+        assert slack_helper.update_message(msg="Hi", recipient="Roger").get("channel") == "Eat"
+        assert slack_helper.update_message(msg="Hi", recipient="Roger").get("text") == "Hi again"
+
+    @patch('app.utils.slackhelper.SlackClient.api_call')
+    def test_user_info_works(
+        self,
+        mock_slack_api_call
+    ):
+        mock_slack_api_call.return_value = {
+            "ok": "true",
+            "user": {
+                "id": "W012A3CDE",
+                "name": "spengler",
+                "deleted": "false",
+                "is_admin": "true",
+            }
+        }
+
+        slack_helper = SlackHelper()
+
+        assert slack_helper.user_info("ururuirn4455").get("ok") == "true"
+        assert slack_helper.user_info("ururuirn4455").get("user").get("id") == "W012A3CDE"
+        assert slack_helper.user_info("ururuirn4455").get("user").get("name") == "spengler"
+        assert slack_helper.user_info("ururuirn4455").get("user").get("deleted") == "false"
+        assert slack_helper.user_info("ururuirn4455").get("user").get("is_admin") == "true"
+
+    @patch('app.utils.slackhelper.SlackClient.api_call')
+    def test_dialog_works(
+        self,
+        mock_slack_api_call
+    ):
+        mock_slack_api_call.return_value = {
+            "ok": "true",
+        }
+
+        slack_helper = SlackHelper()
+
+        dialog = {
+            "callback_id": "ryde-46e2b0",
+            "title": "Request a Ride",
+            "submit_label": "Request",
+            "state": "Limo",
+            "elements": [
+                {
+                    "type": "text",
+                    "label": "Pickup Location",
+                    "name": "loc_origin"
+                },
+                {
+                    "type": "text",
+                    "label": "Dropoff Location",
+                    "name": "loc_destination"
+                }
+            ]
+        }
+
+        assert slack_helper.dialog(dialog,"12.ab").get("ok") == "true"
+
+    @patch('app.utils.slackhelper.SlackClient.api_call')
+    def test_find_by_email_works(
+        self,
+        mock_slack_api_call
+    ):
+        slack_helper = SlackHelper()
+
+        mock_slack_api_call.return_value = {
+            "ok": "true",
+            "user": {
+                "id": "W012A3CDE",
+                "name": "spengler",
+                "deleted": "false",
+                "is_admin": "true",
+                "profile": {
+                    "email":"eat@andela.com"
+                }
+            }
+        }
+
+        assert slack_helper.find_by_email("eats@andela.com").get("ok") == "true"
+        assert slack_helper.find_by_email("eats@andela.com").get("user").get("id") == "W012A3CDE"
+        assert slack_helper.find_by_email("eats@andela.com").get("user").get("name") == "spengler"
+        assert slack_helper.find_by_email("eats@andela.com").get("user").get("deleted") == "false"
+        assert slack_helper.find_by_email("eats@andela.com").get("user").get("is_admin") == "true"
+        assert slack_helper.find_by_email("eats@andela.com").get("user").get("profile").get("email") == "eat@andela.com"


### PR DESCRIPTION
**What does this PR do?**
- Increases test coverage of the `slackhelper.py` file located in `app/utils/slackhelper.py`  file to 100%

**Description of Task to be completed?**
- Write tests to cover all lines of the `slackhelper.py` file

**How should this be manually tested?**
- Pull this branch locally by running `git fetch ch-increase-slack-helper-test-coverage-163973598`
- Checkout to the branch
- Run the command `pytest --cov=app/` to get the coverage for the app
- Run the command `coveralls html` to generate a html coverage report
- Navigate to `andelaeatsapi/htmlcov/index.html` and view the coverage of slackhelper.py file
- The coverage should be at 100%

**Any background context you want to provide?**
- Previously the test coverage of the `slackhelper.py` file was at about 69%

**What are the relevant pivotal tracker stories?**
- [#163973598](https://www.pivotaltracker.com/story/show/163973598)