### PR TITLE
#163980458- Increase andela service files test coverage

### DIFF
--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -122,3 +122,14 @@ class BaseTestCase(TestCase):
 		else:
 			assert False
 
+	@staticmethod
+	def construct_mock_response(json_data, status_code):
+		class MockResponseClass:
+			def __init__(self, json_data, status_code):
+				self.json_data = json_data
+				self.status_code = status_code
+
+			def json(self):
+				return self.json_data
+
+		return MockResponseClass(json_data, status_code)

--- a/tests/unit/services/test_andela_service.py
+++ b/tests/unit/services/test_andela_service.py
@@ -1,0 +1,73 @@
+"""Unit tests for app.services.andela.py
+"""
+from unittest.mock import patch
+
+from app.services.andela import AndelaService
+from tests.base_test_case import BaseTestCase
+
+
+class TestAndelaService(BaseTestCase):
+
+    def setUp(self):
+        self.BaseSetUp()
+
+    @patch('app.services.andela.requests.request')
+    def test_call_returns_json(
+        self,
+        mock_request_class
+    ):
+        service = AndelaService()
+
+        response = self.construct_mock_response({"key":"value"}, 200)
+
+        mock_request_class.return_value = response
+
+        assert service.call("POST", "/andelserviceapi", email="user@andela.com").get("key") == "value"
+
+    @patch('app.services.andela.requests.request')
+    def test_call_returns_exception(
+        self,
+        mock_request_class
+    ):
+        service = AndelaService()
+
+        response = self.construct_mock_response({"key":"value"}, 400)
+
+        mock_request_class.return_value = response
+
+        self.assertRaises(Exception, service.call, "POST", "/andelserviceapi", email="user@andela.com")
+
+    @patch('app.services.andela.AndelaService.call')
+    @patch('app.services.andela.Cache.get')
+    def test_get_user_by_email_or_id_returns_none(
+        self,
+        mock_Cache_get_method,
+        mock_AndelaService_call_method
+    ):
+        mock_Cache_get_method.return_value = None
+        mock_AndelaService_call_method.return_value = {"values":""}
+
+        service = AndelaService()
+
+        user = service.get_user_by_email_or_id("123")
+
+        assert user is None
+
+    @patch('app.services.andela.Cache.get')
+    @patch('app.services.andela.Cache.set')
+    @patch('app.services.andela.AndelaService.call')
+    def test_get_user_by_email_or_id_returns_user(
+        self,
+        mock_AndelaService_call_method,
+        mock_Catch_set_method,
+        mock_Catch_get_method
+    ):
+        mock_AndelaService_call_method.return_value = {"values":["user_1","user_2"]}
+        mock_Catch_set_method.return_value = None
+        mock_Catch_get_method.return_value = None
+
+        service = AndelaService()
+
+        user = service.get_user_by_email_or_id("user_1@email.com")
+
+        assert user == "user_1"


### PR DESCRIPTION
**What does this PR do?**
- Increases test coverage of the `andela.py` file located in `app/services`  file to 100%

**Description of Task to be completed?**
- Write tests to cover all lines of the `andela.py` file

**How should this be manually tested?**
- Pull this branch locally by running `git fetch ch-increase-andela-service-test-coverage-163980458`
- Checkout to the branch
- Run the command `pytest --cov=app/` to get the coverage for the app
- Run the command `coveralls html` to generate a html coverage report
- Navigate to `andelaeatsapi/htmlcov/index.html` and view the coverage of andela.py file
- The coverage should be at 100%

**Any background context you want to provide?**
- Previously the test coverage of the `andela.py` file was not 100%

**What are the relevant pivotal tracker stories?**
- [#163980458](https://www.pivotaltracker.com/story/show/163980458)