### PR TITLE
#164008849 - Fix sort order of returned vendor data

### DIFF
--- a/app/controllers/vendor_controller.py
+++ b/app/controllers/vendor_controller.py
@@ -16,7 +16,11 @@ class VendorController(BaseController):
 
 	def list_vendors(self):
 		location = Auth.get_location()
-		vendors = self.vendor_repo.filter_by(is_deleted=False, is_active=True, location_id=location)
+		vendors = self.vendor_repo.filter_by_asc(
+			self.vendor_repo._model.name,
+			is_deleted=False,
+			is_active=True,
+			location_id=location)
 		vendors_list = [vendor.serialize() for vendor in vendors.items]
 		return self.handle_response('OK', payload={'vendors': vendors_list, 'meta': self.pagination_meta(vendors)})
 

--- a/tests/integration/endpoints/test_vendor_endpoints.py
+++ b/tests/integration/endpoints/test_vendor_endpoints.py
@@ -37,7 +37,25 @@ class TestVendorEndpoints(BaseTestCase):
 		self.assert200(response)
 		self.assertEqual(len(payload['vendors']), 3)
 		self.assertJSONKeysPresent(payload['vendors'][0], 'name', 'tel', 'id', 'address', 'contactPerson','timestamps')
-		
+
+	def test_list_vendors_endpoint_returns_data_sorted_by_name(self):
+		location = LocationFactory(id=self.headers()['X-Location'])
+		# Create Three Dummy Vendors
+		vendors = VendorFactory.create_batch(3, location_id=location.id)
+
+		response = self.client().get(self.make_url('/vendors/'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+
+		sorted_vendor_names = sorted([vendor.name for vendor in vendors])
+		vendors = payload['vendors']
+
+		self.assert200(response)
+		self.assertEqual(len(payload['vendors']), 3)
+		self.assertEqual(sorted_vendor_names[0], vendors[0].get('name'))
+		self.assertEqual(sorted_vendor_names[1], vendors[1].get('name'))
+		self.assertEqual(sorted_vendor_names[2], vendors[2].get('name'))
+
 	def test_get_specific_vendor_enpoint(self):
 		vendor = VendorFactory.create()
 		response = self.client().get(self.make_url('/vendors/{}'.format(vendor.id)), headers=self.headers())


### PR DESCRIPTION
**What does this PR do?**
- Fixes issues with a get request on the endpoint `/api/v1/vendors/` not returning data sorted according to the `name`

**Description of Task to be completed?**
- Refactor the list_vendors method of the VendorController class to extract engagements sorted in ascending order of `name`
- Write tests for the newly added code.

**How should this be manually tested?**
- Pull this branch locally by running `git fetch bg-sort-vendor-data-in-asc-by-name-164008849`
- Create three vendors, with their names in any order, by performing a post on the endpoint `api/v1/vendors/`
- Perform a get request on the endpoint `api/v1/vendors/` and you should be able to get results sorted according to `vendor names` in ascending order.

**Any background context you want to provide?**
- Previously it was not possible to return data from the `api/v1/vendors/` sorted according to the `name`. 

**What are the relevant pivotal tracker stories?**

- [#164008849](https://www.pivotaltracker.com/story/show/164008849)