### PR TITLE
#164014105 - Fix sort order of returned meal_item data to ascending by name

### DIFF
--- a/app/controllers/meal_item_controller.py
+++ b/app/controllers/meal_item_controller.py
@@ -12,7 +12,11 @@ class MealItemController(BaseController):
     
     def list_meals(self):
         location_id = Auth.get_location()
-        meals = self.meal_repo.get_unpaginated(is_deleted=False, location_id=location_id)
+        meals = self.meal_repo.get_unpaginated_asc(
+            self.meal_repo._model.name,
+            is_deleted=False,
+            location_id=location_id
+        )
         meals_list = [meal.serialize() for meal in meals]
         return self.handle_response('OK', payload={'mealItems': meals_list})
 

--- a/app/repositories/base_repo.py
+++ b/app/repositories/base_repo.py
@@ -60,7 +60,16 @@ class BaseRepo:
 	def get_unpaginated(self, **kwargs):
 		"""Query and filter the data of the model."""
 		return self._model.query.filter_by(**kwargs).all()
-	
+
+	def get_unpaginated_asc(self, *args, **kwargs):
+		"""Query and filter the data of the model in ascending order."""
+		return self._model.query.filter_by(**kwargs).order_by(asc(*args)) \
+			.all()
+
+	def get_unpaginated_desc(self, *args, **kwargs):
+		"""Query and filter the data of the model in ascending order."""
+		return self._model.query.filter_by(**kwargs).order_by(desc(*args)) \
+			.all()
 	
 	def find_first(self, **kwargs):
 		"""Query and filter the data of a model, returning the first result."""

--- a/tests/integration/endpoints/test_meal_items_endpoints.py
+++ b/tests/integration/endpoints/test_meal_items_endpoints.py
@@ -139,6 +139,32 @@ class TestMealItemEndpoints(BaseTestCase):
 		self.assertEqual(len(payload['mealItems']), 3)
 		self.assertJSONKeysPresent(payload['mealItems'][0], 'name', 'description', 'mealType', 'image')
 
+	def test_list_meal_item_endpoint_correct_sort_order(self):
+		# Create Three Dummy Vendors
+		meals = MealItemFactory.create_batch(3)
+
+		role = RoleFactory.create(name='admin')
+		user_id = BaseTestCase.user_id()
+		PermissionFactory.create(keyword='view_meal_item', role_id=role.id)
+		UserRoleFactory.create(user_id=user_id, role_id=role.id)
+
+		response = self.client().get(self.make_url('/meal-items/'), headers=self.headers())
+		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+		payload = response_json['payload']
+
+		meals_sorted_by_name = sorted(
+			[meal.name for meal in meals]
+		)
+
+		meals_returned = [meal.get("name") for meal in payload['mealItems']]
+
+		self.assert200(response)
+		self.assertEqual(len(payload['mealItems']), 3)
+		self.assertJSONKeysPresent(payload['mealItems'][0], 'name', 'description', 'mealType', 'image')
+		self.assertEqual(meals_returned[0], meals_sorted_by_name[0])
+		self.assertEqual(meals_returned[1], meals_sorted_by_name[1])
+		self.assertEqual(meals_returned[2], meals_sorted_by_name[2])
+
 	def test_list_meal_item_endpoint_wrong_permission(self):
 		# Create Three Dummy Vendors
 		meals = MealItemFactory.create_batch(3)

--- a/tests/integration/endpoints/test_vendor_engagement_endpoints.py
+++ b/tests/integration/endpoints/test_vendor_engagement_endpoints.py
@@ -152,12 +152,11 @@ class TestVendorEngagementEndpoints(BaseTestCase):
 
 		role = RoleFactory.create(name='admin')
 		user_id = BaseTestCase.user_id()
-		permission = PermissionFactory.create(keyword='delete_engagement', role_id=100)
+		permission = PermissionFactory.create(keyword='delete_engagement', role_id=1000)
 		user_role = UserRoleFactory.create(user_id=user_id, role_id=role.id)
 
 		response = self.client().delete(self.make_url(f'/engagements/{engagement.id}'), headers=self.headers())
 		response_json = self.decode_from_json_string(response.data.decode('utf-8'))
-
 		self.assert400(response)
 		self.assertEqual(response_json['msg'], 'Access Error - No Permission Granted')
 

--- a/tests/unit/repositories/test_base_repo.py
+++ b/tests/unit/repositories/test_base_repo.py
@@ -17,6 +17,31 @@ class TestBaseRepository(BaseTestCase):
 		self.assertEqual(vendor.id, vendor_.id)
 		self.assertEqual(vendor.tel, vendor_.tel)
 		self.assertEqual(vendor.address, vendor_.address)
+
+	def test_get_unpaginated_asc_orders_ascending(self):
+		vendor_1 = VendorFactory.create()
+		vendor_2 = VendorFactory.create()
+
+		vendor_names = sorted([vendor.name for vendor in [vendor_1, vendor_2]])
+
+		results = self.repo.get_unpaginated_asc(Vendor.name)
+
+		self.assertEqual(vendor_names[0], results[0].name)
+		self.assertEqual(vendor_names[1], results[1].name)
+
+	def test_get_unpaginated_desc_orders_ascending(self):
+		vendor_1 = VendorFactory.create()
+		vendor_2 = VendorFactory.create()
+
+		vendor_names = sorted(
+			[vendor.name for vendor in [vendor_1, vendor_2]],
+			reverse=True
+		)
+
+		results = self.repo.get_unpaginated_desc(Vendor.name)
+
+		self.assertEqual(vendor_names[0], results[0].name)
+		self.assertEqual(vendor_names[1], results[1].name)
 		
 	def test_update_method_updates_model_values(self):
 		vendor = VendorFactory()


### PR DESCRIPTION
**What does this PR do?**
- Fixes issues with a get request on the endpoint `/api/v1/meal-items/` not returning data sorted according to the `name`

**Description of Task to be completed?**
- Modify `list_meals` method of the `MealItemController`class located in the `meal_item_controller.py` file to return data unpaginated and sorted by `meal_item name`
- Add two methods to the `BaseRepo`; one to get unpaginated data in ascending order and the other to get unpaginated data in descending order.
- Add tests for code just added
- Refactor any other failing tests

**How should this be manually tested?**
- Pull this branch locally by running `git fetch bg-fix-meal-list-data-sort-order-164014105`
- Create three vendors, with their names in any order, by performing a post on the endpoint `api/v1/meal-items/`
- Perform a get request on the endpoint `api/v1/meal-items/` and you should be able to get results sorted according to `meal-item names` in ascending order.

**Any background context you want to provide?**
- Previously it was not possible to return data from the `api/v1/meal-items/` sorted according to the `name`. 

**What are the relevant pivotal tracker stories?**

- [#164014105](https://www.pivotaltracker.com/story/show/164014105)