### PR TITLE
Add more tests to the bot controller and bot blueprint

### DIFF
--- a/tests/mock.py
+++ b/tests/mock.py
@@ -1,9 +1,95 @@
 center_selected = {
-    'type': 'interactive_message',
-    'actions': [{'name': 'location', 'type': 'button', 'value': '1'}],
-    'callback_id': 'center_selector',
-    'attachment_id': '1',
-    'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
-    'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/549527916742/rrCypS2U3mPs5USyvOzwMOgb',
-    'trigger_id': '548310892565.2853699384.949752a7af3d9b66735aa03ca1aad01c'
+        "type": "interactive_message",
+        "actions": [{"name": "location", "type": "button", "value": "1"}],
+        "callback_id": "center_selector",
+        "team": {'id': "T02R3LKBA", "domain": "andela"},
+        "channel": {"id": "D88KHH37V", "name": "directmessage"},
+        "user": {"id": "U882C5UC8", "name": "victor.adukwu"},
+        "action_ts": "1549957880.052215",
+        "message_ts": "1549957877.002300",
+        "attachment_id": "1",
+        "token": "g1Cry9evBQwCkCLEUxZKA0QH",
+        "is_app_unfurl": False,
+        "response_url": "https://hooks.slack.com/actions/T02R3LKBA/548311943188/nBI58tzUgH3btRRO7Yc7eZMU",
+        "trigger_id": "549537993895.2853699384.8fba119455dadb0292195008c6b51ab0"
+}
+
+date_selected = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'selected_date','type': 'button', 'value': '2019-02-18_1'}],
+        'callback_id': 'day_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'GBE9NJMGQ', 'name': 'privategroup'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550264646.456293',
+        'message_ts': '1550264324.003400',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/554077116518/7Hqylc9wga4dr5uNYGkMZWhc',
+        'trigger_id': '552645730370.2853699384.9f96d124dec19b1e47f87d42a4d28196'
+}
+
+period_selected = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'meal_period', 'type': 'button', 'value': 'breakfast_2019-02-18_1'}],
+        'callback_id': 'period_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'GBE9NJMGQ', 'name': 'privategroup'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550267485.414517',
+        'message_ts': '1550267344.003500',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/553007489909/Y372gp2uHy2gXrQCgq074DXA',
+        'trigger_id': '551936635328.2853699384.82dad4e19261f1b2766aba72a404a407'
+}
+
+action_selected_menu = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'main meal', 'type': 'button', 'value': 'breakfast_2019-02-18_menu_1'}],
+        'callback_id': 'action_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'G07EEMW74', 'name': 'privategroup'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550268961.405508',
+        'message_ts': '1550268769.151700',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/553771957207/txGyAa8jEJC1Ulrmapd7wrLR',
+        'trigger_id': '552132311505.2853699384.58d460a320df36f954f2368ac02e9e29'
+}
+
+action_selected_order = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'main meal', 'type': 'button', 'value': 'breakfast_2019-02-18_order_1'}],
+        'callback_id': 'action_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'G07EEMW74', 'name': 'privategroup'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550268961.405508',
+        'message_ts': '1550268769.151700',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/553771957207/txGyAa8jEJC1Ulrmapd7wrLR',
+        'trigger_id': '552132311505.2853699384.58d460a320df36f954f2368ac02e9e29'
+}
+
+menu_list_rate = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'main meal', 'type': 'button', 'value': 'breakfast_2019-02-18_rate_1_1'}],
+        'callback_id': 'after_menu_list',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'G07EEMW74', 'name': 'privategroup'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550271003.195004',
+        'message_ts': '1550270677.151900',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/552154971185/E9rKlt4e2pEpaI9QtoYBB0Zh',
+        'trigger_id': '554159184566.2853699384.109e7d47f9800294ccf30c3d4d1c0201'
 }


### PR DESCRIPTION
**What does this PR do?**

* Increase the test coverage of bot controller and  add 100% coverage for bot blueprint

**Description of Task to be completed?**

* Add test for various stages of the slack bot interactions
* 100 % coverage for the bot blueprint

**How should this be manually tested?**
Run the command ` pytest --cov=app.controllers.bot_controller tests/integration/endpoints/test_bot_endpoints.py
` to see the coverage

**Any background context you want to provide?**

* None

**What are the relevant pivotal tracker stories?**

 