### PR TITLE
Increase test coverage of bot controller to 99%

### DIFF
--- a/app/controllers/bot_controller.py
+++ b/app/controllers/bot_controller.py
@@ -309,7 +309,7 @@ class BotController(BaseController):
                     slack_data = {'text': 'You already have an order for this meal period.'}
                     requests.post(webhook_url, data=json.dumps(slack_data),
                                   headers={'Content-Type': 'application/json'})
-                    return
+                    return self.handle_response(status_code=400)
                 trigger_id = payload['trigger_id']
 
                 side_items_list = menu.side_items.split(',')

--- a/tests/integration/endpoints/test_bot_endpoints.py
+++ b/tests/integration/endpoints/test_bot_endpoints.py
@@ -1,8 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 from datetime import datetime
+import unittest
 from tests.base_test_case import BaseTestCase
 from app.controllers import BotController
-from factories import LocationFactory, MenuFactory
+from factories import LocationFactory, MenuFactory, MealItemFactory, VendorEngagementFactory
 from tests.mock import (
     center_selected,
     date_selected,
@@ -10,6 +11,11 @@ from tests.mock import (
     action_selected_menu,
     action_selected_order,
     menu_list_rate,
+    meal_to_book,
+    final_selection,
+    final_selection_invalid,
+    rating_selector,
+    submit_rating
 )
 
 
@@ -80,9 +86,37 @@ class TestBotEndpoints(BaseTestCase):
         self.assertEqual(response_json['type'], 'interactive_message')
         self.assertEqual(type(response_json['actions']), list)
 
+    @patch('app.repositories.MenuRepo.get_unpaginated')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_action_menu_list_with_menus(self, mock_json_loads, mock_menu_repo):
+        mock_json_loads.return_value = action_selected_menu
+        mock_menu_repo.return_value = [self.menu_factory.create()]
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'interactive_message')
+        self.assertEqual(type(response_json['actions']), list)
+
     @patch('app.controllers.bot_controller.json.loads')
     def test_interactions_after_selecting_action_order(self, mock_json_loads):
         mock_json_loads.return_value = action_selected_order
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'interactive_message')
+        self.assertEqual(type(response_json['actions']), list)
+
+    @patch('app.utils.slackhelper.SlackHelper.dialog')
+    @patch('app.repositories.MenuRepo.get_unpaginated')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_action_order_with_menus(self, mock_json_loads, mock_menu_repo, mock_api):
+        mock_json_loads.return_value = action_selected_order
+        mock_menu_repo.return_value = [self.menu_factory.create()]
+        mock_api.return_value = { 'ok': True }
 
         response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
         response_json = self.decode_from_json_string(response.data.decode('utf-8'))
@@ -101,6 +135,142 @@ class TestBotEndpoints(BaseTestCase):
         self.assert200(response)
         self.assertEqual(response_json['type'], 'interactive_message')
         self.assertEqual(type(response_json['actions']), list)
+
+    @patch('app.repositories.MenuRepo.get_unpaginated')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_menulist_rate_with_menus(self, mock_json_loads, mock_menu_repo):
+        mock_json_loads.return_value = menu_list_rate
+        mock_menu_repo.return_value = [self.menu_factory.create()]
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'interactive_message')
+        self.assertEqual(type(response_json['actions']), list)
+
+    @patch('app.utils.slackhelper.SlackHelper.dialog')
+    @patch('app.controllers.bot_controller.requests.post')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.repositories.OrderRepo.user_has_order')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_menu_to_order_invalid(self, mock_json_loads, mock_user_info, mock_order_repo, mock_andela_service, mock_menu_repo, mock_post, mock_api_call):
+        mock_json_loads.return_value = meal_to_book
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com'}
+        mock_menu_repo.return_value = Mock(self.menu_factory.create())
+        mock_order_repo.return_value = True
+        mock_api_call.return_value = { "ok": True }
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        mock_post.assert_called_once()
+
+        self.assert400(response)
+
+    @patch('app.utils.slackhelper.SlackHelper.dialog')
+    @patch('app.repositories.MealItemRepo.get_meal_items_by_ids')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.repositories.OrderRepo.user_has_order')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_menu_to_order_valid(self, mock_json_loads, mock_user_info, mock_order_repo,
+                                                        mock_andela_service, mock_menu_repo, mock_meal_items, mock_api_call):
+        mock_json_loads.return_value = meal_to_book
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com'}
+        mock_menu_repo.return_value = self.menu_factory.create(allowed_side=1, allowed_protein=1)
+        mock_meal_items.return_values = MealItemFactory.create()
+        mock_order_repo.return_value = False
+        mock_api_call.return_value = { "ok": True}
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+
+        self.assert200(response)
+
+    @patch('app.controllers.bot_controller.requests.post')
+    @patch('app.repositories.MealItemRepo.get_meal_items_by_ids')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.repositories.OrderRepo.user_has_order')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_final_meal_selection(self, mock_json_loads, mock_user_info, mock_order_repo, mock_andela_service, mock_menu_repo, mock_meal_items, mock_post):
+        mock_json_loads.return_value = final_selection
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com', 'email': 'victor.adukwu@andela.com'}
+        mock_menu_repo.return_value = self.menu_factory.create()
+        mock_order_repo.return_value = True
+        mock_meal_items.return_values = MealItemFactory.create()
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'dialog_submission')
+        mock_post.assert_called_once()
+
+    @patch('app.utils.slackhelper.SlackHelper.dialog')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_selecting_menu_to_rate(self, mock_json_loads, mock_user_info,
+                                                              mock_andela_service, mock_menu_repo, mock_api_call):
+        mock_json_loads.return_value = rating_selector
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com'}
+        mock_menu_repo.return_value = self.menu_factory.create(allowed_side=1, allowed_protein=1)
+        mock_api_call.return_value = {"ok": True}
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+
+        self.assert200(response)
+
+    @patch('app.controllers.bot_controller.requests.post')
+    @patch('app.repositories.VendorEngagementRepo.get')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_final_meal_selection_valid(self, mock_json_loads, mock_user_info,
+                                                     mock_andela_service, mock_menu_repo, mock_engagement_repo, mock_post):
+        mock_json_loads.return_value = submit_rating
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com'}
+        mock_engagement_repo.return_value = VendorEngagementFactory.create()
+        mock_menu_repo.return_value = self.menu_factory.create()
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+        mock_post.assert_called_once()
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'dialog_submission')
+
+    @patch('app.controllers.bot_controller.requests.post')
+    @patch('app.repositories.VendorRatingRepo.new_rating')
+    @patch('app.repositories.VendorEngagementRepo.get')
+    @patch('app.repositories.MenuRepo.get')
+    @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
+    @patch('app.utils.slackhelper.SlackHelper.user_info')
+    @patch('app.controllers.bot_controller.json.loads')
+    def test_interactions_after_final_meal_selection_invalid(self, mock_json_loads, mock_user_info,
+                                                     mock_andela_service, mock_menu_repo, mock_engagement_repo,
+                                                     rating_repo, mock_post):
+        mock_json_loads.return_value = submit_rating
+        mock_user_info.return_value = {'user': {'profile': {'email': 'victor.adukwu@andela.com'}}}
+        mock_andela_service.return_value = {'id': 'victor_adukwu_andela_com'}
+        mock_engagement_repo.return_value = VendorEngagementFactory.create()
+        mock_menu_repo.return_value = self.menu_factory.create()
+        rating_repo.return_value = None
+
+        response = self.client().post(self.make_url(f'/bot/interactions/'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+        mock_post.assert_called_once()
+        self.assert200(response)
+        self.assertEqual(response_json['type'], 'dialog_submission')
 
     @patch('app.controllers.bot_controller.current_time_by_zone')
     def test_get_menu_start_end_on_before_3pm_sunday(self, mock_get):

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -93,3 +93,75 @@ menu_list_rate = {
         'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/552154971185/E9rKlt4e2pEpaI9QtoYBB0Zh',
         'trigger_id': '554159184566.2853699384.109e7d47f9800294ccf30c3d4d1c0201'
 }
+
+meal_to_book = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'main_meal', 'type': 'button', 'value': '7_breakfast_2019-02-19_order_1_1'}],
+        'callback_id': 'meal_action_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'D88KHH37V', 'name': 'directmessage'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550491702.965015',
+        'message_ts': '1550491641.008000',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/554103071989/6jNpGBwjoLjFVEORKVxjQWyv',
+        'trigger_id': '553207761761.2853699384.d9f8b287d8d5b2067b754a510098acb5'
+}
+
+
+final_selection = {
+        'type': 'dialog_submission',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'action_ts': '1550489752.583813',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'channel': {'id': 'D88KHH37V', 'name': 'directmessage'},
+        'submission': {'side_1': '13', 'protein_1': '13'},
+        'callback_id': 'final_selection',
+        'response_url': 'https://hooks.slack.com/app/T02R3LKBA/553185145713/DkDJSPSpCMlAxPGPGhZ8LXps',
+        'state': '7_breakfast_2019-02-19_order_1_1'
+}
+
+final_selection_invalid = {
+        'type': 'dialog_submission',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'action_ts': '1550489752.583813',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'channel': {'id': 'D88KHH37V', 'name': 'directmessage'},
+        # 'submission': {'side_1': '13', 'protein_1': '13'},
+        'callback_id': 'final_selection',
+        'response_url': 'https://hooks.slack.com/app/T02R3LKBA/553185145713/DkDJSPSpCMlAxPGPGhZ8LXps',
+        'state': '7_breakfast_2019-02-19_order_1_1'
+}
+
+rating_selector = {
+        'type': 'interactive_message',
+        'actions': [{'name': 'main_meal', 'type': 'button', 'value': '7_breakfast_2019-02-20_rate_1_1'}],
+        'callback_id': 'rating_selector',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'channel': {'id': 'D88KHH37V', 'name': 'directmessage'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'action_ts': '1550527333.836668',
+        'message_ts': '1550526751.008200',
+        'attachment_id': '1',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'is_app_unfurl': False,
+        'response_url': 'https://hooks.slack.com/actions/T02R3LKBA/554243423410/TjaH6eImHVWT0LzjdKI2ptbi',
+        'trigger_id': '555310992407.2853699384.3076067024b166443b15c8b9e4e191f7'
+}
+
+submit_rating = {
+        'type': 'dialog_submission',
+        'token': 'g1Cry9evBQwCkCLEUxZKA0QH',
+        'action_ts': '1550527598.156108',
+        'team': {'id': 'T02R3LKBA', 'domain': 'andela'},
+        'user': {'id': 'U882C5UC8', 'name': 'victor.adukwu'},
+        'channel': {'id': 'D88KHH37V', 'name': 'directmessage'},
+        'submission': {'rating value': '4', 'comment': 'Cool'},
+        'callback_id': 'submit_rating',
+        'response_url': 'https://hooks.slack.com/app/T02R3LKBA/553672885921/SF8yNuOiNWbKNqZhtikd77wt',
+        'state': '7_breakfast_2019-02-20_rate_1_1'
+}


### PR DESCRIPTION
**What does this PR do?**

* Increase the test coverage of bot controller to 99% 

**Description of Task to be completed?**

* Add test for various stages of the slack bot interactions
* 99% coverage for the bot controller

**How should this be manually tested?**
Run the command ` pytest --cov=app.controllers.bot_controller tests/integration/endpoints/test_bot_endpoints.py
` to see the coverage

**Any background context you want to provide?**

* None

**What are the relevant pivotal tracker stories?**

 