### PR TITLE
#164046943 - Modify menu endpoint

### DIFF
--- a/app/repositories/menu_repo.py
+++ b/app/repositories/menu_repo.py
@@ -35,4 +35,4 @@ class MenuRepo(BaseRepo):
         return Menu.query.filter(
             Menu.date >= start_date, Menu.date <= end_date, Menu.meal_period == meal_period, Menu.is_deleted.is_(False),
             Menu.location_id == location_id
-        ).order_by(Menu.date.asc()).paginate(error_out=False)
+        ).order_by(Menu.date.desc()).paginate(error_out=False)


### PR DESCRIPTION
**What does this PR do?**
- Fixes issues with a get request on the endpoint `/api/v1/admin/menus/{meal_period}/{start_date}/{end_date}` not returning data sorted in descending order according to the `date` field.

**Description of Task to be completed?**
- Modify `get_range_paginated_options` method of the `MenuRepo` class to return data sorted in descending order by `date`

**How should this be manually tested?**
- Pull this branch locally by running `git fetch bg-sort-menus-in-descending-order-164046943`
- Run `Pytest`

**Any background context you want to provide?**
- Previously data on `/api/v1/admin/menus/{meal_period}/{start_date}/{end_date}` endpoint was returning data sorted in ascending order according to the `date` field.

**What are the relevant pivotal tracker stories?**

- [#164046943](https://www.pivotaltracker.com/story/show/164046943)