### PR TITLE
#164099935 update token decoding functionality to include expired token check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           FLASK_APP: run
           FLASK_ENV: development
           APP_ENV: testing
+          DATABASE_TEST_URL: 'sqlite:///andelaeats.db'
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -53,26 +53,27 @@ class Auth:
 
     @staticmethod
     def _get_jwt_public_key():
-
         decode_public_key = lambda key_64: b64decode(key_64).decode('utf-8')
 
         jwt_env_mapper = {
             'testing': 'JWT_PUBLIC_KEY_TEST',
             'production': 'JWT_PUBLIC_KEY',
-            'development': 'JWT_PUBLIC_KEY_TEST'
+            'development': 'JWT_PUBLIC_KEY',
+            'staging': 'JWT_PUBLIC_KEY'
         }
 
         public_key_mapper = {
             'testing': lambda key_64: key_64,
-            'development': lambda key_64: key_64,
+            'development': decode_public_key,
             'production': decode_public_key,
+            'staging': decode_public_key,
         }
-        flask_env = getenv('FLASK_ENV', 'production')
 
-        public_key_64 = getenv(jwt_env_mapper.get(flask_env, 'JWT_PUBLIC_KEY_STAGING'))
+        app_env = getenv('APP_ENV', 'production')
 
-        public_key = public_key_mapper.get(
-            flask_env, decode_public_key)(public_key_64)
+        public_key_64 = getenv(jwt_env_mapper.get(app_env, 'JWT_PUBLIC_KEY'))
+
+        public_key = public_key_mapper.get(app_env, decode_public_key)(public_key_64)
 
         return public_key
 

--- a/config/env.py
+++ b/config/env.py
@@ -33,8 +33,8 @@ class TestingEnv(EnvConfig):
     TESTING = True
     # SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/andelaeats_test'
     # SQLALCHEMY_POOL_TIMEOUT = 1000
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///andelaeats.db'
-    # SQLALCHEMY_DATABASE_URI = get_env('DATABASE_TEST_URL')
+    # SQLALCHEMY_DATABASE_URI = 'sqlite:///andelaeats.db'
+    SQLALCHEMY_DATABASE_URI = get_env('DATABASE_TEST_URL')
 
     DEBUG = True
     PRESERVE_CONTEXT_ON_EXCEPTION = False


### PR DESCRIPTION
**What does this PR do?**
* update token decoding functionality to include a check for token expiry

**Description of Task to be completed?**
* update token decoding functionality to include a check for token expiry

**How should this be manually tested?**
* Add the Andela JWT decode public keys `JWT_PUBLIC_KEY` and `JWT_PUBLIC_KEY_STAGING`
to the `.env` file and try making a request to any endpoint with an expired token. The request should be unsuccessful with the `Token expired` message.

**Any background context you want to provide?**

* The token decoding process initially was not checking for token expiry. 

**What are the relevant pivotal tracker stories?**

* [64099935](https://www.pivotaltracker.com/story/show/64099935) 

[Maintains #164099935]