### PR TITLE
Enable rating of menu from previous day

### DIFF
--- a/app/blueprints/documentation/create_order_rating.yml
+++ b/app/blueprints/documentation/create_order_rating.yml
@@ -1,8 +1,8 @@
-Create a Order Rating
+Create Order or menu Rating
 ---
 tags:
   - Vendor Ratings
-summary: Creates a new order rating.
+summary: Creates a new order rating. Also create menu rating for the previous day.
 consumes:
   - application/json
 parameters:
@@ -19,14 +19,9 @@ parameters:
     description: Bearer Token Value
   - in: body
     name: menu
-    description: Creation of an order Rating
+    description: Creation of an order rating  or menu rating
     schema:
       type: object
-      required:
-        - orderId or mainMealId
-        - comment
-        - rating
-        - channel
       properties:
         orderId:
           type: integer
@@ -35,7 +30,7 @@ parameters:
           type: integer
           required: true
         serviceDate:
-          descrition: The day the meal or order was served
+          description: The day the meal or order was served
           type: date
           required: true
         comment:
@@ -44,9 +39,13 @@ parameters:
         rating:
           type: number
           required: true
+        engagementId:
+          type: number
+          description: the id of the vendor engagement
+          required: true
         channel:
           type: string
-          required: true
+          required: optional
 definitions:
   VendorRatingPayload:
     type: object

--- a/app/controllers/vendor_rating_controller.py
+++ b/app/controllers/vendor_rating_controller.py
@@ -92,6 +92,8 @@ class VendorRatingController(BaseController):
                 return self.handle_response('This order has been rated', status_code=400)
 
         else:
+            if (datetime.now() - datetime.strptime(service_date, '%Y-%m-%d')).days < 1:
+                return self.handle_response('You can only rate meals of past days.', status_code=400)
             rating_type = RatingType.meal
             type_id = main_meal_id
             user_meal_rating = self.vendor_rating_repo.get_unpaginated(user_id=user_id, type_id=type_id, rating_type='meal')

--- a/tests/unit/controllers/test_vendor_rating_controller.py
+++ b/tests/unit/controllers/test_vendor_rating_controller.py
@@ -527,8 +527,9 @@ class TestVendorRatingController(BaseTestCase):
                 engagement_id=1,
                 main_meal_id=1
             )
+            service_date = datetime.strftime((datetime.now() - timedelta(1)).date(), '%Y-%m-%d')
             mock_vendor_rating_controller_request_params.return_value = (
-                None, None, None, None, 3, None, None
+                None, None, None, None, 3, service_date, None
             )
             mock_auth_user.return_value = 1
             mock_meal_item_repo_get.return_value = mock_meal_item


### PR DESCRIPTION
**What does this PR do?**

* Add ability to rate previous day manu

**Description of Task to be completed?**

* update the meal rating endpoint so user can only rate past meal
* update the endpoint documentation
* fix failing tests

**How should this be manually tested?**
* pull the branch `rate-past-meal` and checkout to the branch
* send  `post` request to `localhost:5000/api/v1/rating/` with the payload:
     `{
	"rating": 5,
	"engagementId": 1 ,
	"mainMealId":1 ,
	"serviceDate": "2019-02-28" 
}`
If the meal serviceDate is is the previous day, the rating will be successful. If you attempt to rate a menu whose service date is today or in the future, the request will fail

**Any background context you want to provide?**

* Users are to be given ability to rate a meal they have eaten even if they did no place an order for it.

**What are the relevant pivotal tracker stories?**

 