### PR TITLE
Fixing bug where listing admin users returned an list 

### DIFF
--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -42,8 +42,8 @@ class UserController(BaseController):
         ).items
 
         admin_users_list = []
-        admin_user_profile = {}
         for user_role in user_roles:
+            admin_user_profile = {}
             andela_user_profile = self.andela_service.get_user_by_email_or_id(
                 user_role.user_id
             )


### PR DESCRIPTION
What does this PR do?
- Fix bug of returning the admin users list duplicating the last admin user entered.

Description of Task to be completed?
- API returned a list of admin users with the last admin user's details duplicated for all the user records to be returned.

How should this be manually tested?
  ```
pytest --cov=app.controllers.user_controller tests/unit/controllers/test_user_controller.py
```

Any background context you want to provide?
- Invalid admin list returned when querying for admin users.

What are the relevant pivotal tracker stories?
[158456181](https://www.pivotaltracker.com/story/show/158456181)
