### PR TITLE
#164240383 Log activities that change state of the database 

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -20,7 +20,7 @@ from .listener_helpers import attach_listen_type
 tables_logged_after_every_insert = [Vendor, VendorEngagement, MealItem, Menu, Faq,
                                     Role, Permission, UserRole, Location]
 tables_logged_after_every_update = [Vendor, VendorEngagement, MealItem, Menu, Faq,
-                                    Role, Permission, UserRole, Location, VendorRating]
+                                    Role, Permission, UserRole, Location]
 tables_logged_after_every_delete = [Vendor, VendorEngagement, MealItem, Menu, Faq,
                                     Role, Permission, UserRole, Location, VendorRating]
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -15,28 +15,16 @@ from .order import Order
 from .activity import Activity
 from .faq import Faq
 
-from .listener_helpers import add_activity
+from .listener_helpers import attach_listen_type
 
-tables = [Vendor]
+tables_logged_after_every_insert = [Vendor, VendorEngagement, MealItem, Menu, Faq,
+                                    Role, Permission, UserRole, Location]
+tables_logged_after_every_update = [Vendor, VendorEngagement, MealItem, Menu, Faq,
+                                    Role, Permission, UserRole, Location, VendorRating]
+tables_logged_after_every_delete = [Vendor, VendorEngagement, MealItem, Menu, Faq,
+                                    Role, Permission, UserRole, Location, VendorRating]
 
-
-def after_insert_listener(mapper, connection, target):
-    add_activity(target)
-
-
-def after_update_listener(mapper, connection, target):
-    add_activity(target, listener_type="update")
-
-
-def after_delete_listener(mapper, connection, target):
-    add_activity(target, listener_type="delete")
-
-
-# Add after_insert, after_update, after_delete listeners to models
-for table in tables:
-   event.listen(table, 'after_insert', after_insert_listener)
-   event.listen(table, 'after_update', after_update_listener)
-   event.listen(table, 'after_delete', after_delete_listener)
-
-
-
+# attach all listeners to each admin table
+attach_listen_type(tables_logged_after_every_insert, 'after_insert')
+attach_listen_type(tables_logged_after_every_update, 'after_update')
+attach_listen_type(tables_logged_after_every_delete, 'after_delete')

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,7 @@
+from flask import request
+from sqlalchemy import event
+
+
 from .location import Location
 from .vendor import Vendor
 from .vendor_engagement import VendorEngagement
@@ -10,3 +14,29 @@ from .meal_item import MealItem
 from .order import Order
 from .activity import Activity
 from .faq import Faq
+
+from .listener_helpers import add_activity
+
+tables = [Vendor]
+
+
+def after_insert_listener(mapper, connection, target):
+    add_activity(target)
+
+
+def after_update_listener(mapper, connection, target):
+    add_activity(target, listener_type="update")
+
+
+def after_delete_listener(mapper, connection, target):
+    add_activity(target, listener_type="delete")
+
+
+# Add after_insert, after_update, after_delete listeners to models
+for table in tables:
+   event.listen(table, 'after_insert', after_insert_listener)
+   event.listen(table, 'after_update', after_update_listener)
+   event.listen(table, 'after_delete', after_delete_listener)
+
+
+

--- a/app/models/listener_helpers.py
+++ b/app/models/listener_helpers.py
@@ -1,0 +1,99 @@
+"""Helpers for event listeners"""
+from sqlalchemy import event
+from datetime import datetime as dt
+
+from app.utils.auth import request
+from app.utils import auth
+from .activity import Activity, db
+
+
+def add_activity(target, listener_type="insert"):
+    """Log any update or change by an admin user"""
+    try:
+        user_id = auth.Auth.user('UserInfo').get('id')
+        ip_address = request.remote_addr
+    except Exception as e:
+        user_id = 'unknown'
+        ip_address = 'unknown'
+
+    model_name = target.__class__.__name__
+
+    target_as_dict = target.to_dict()
+    target_as_dict["created_at"] = target_as_dict["created_at"].strftime('%Y-%m-%dT%H:%M:%S.%f')
+    target_as_dict["updated_at"] = target_as_dict["updated_at"].strftime('%Y-%m-%dT%H:%M:%S.%f')
+
+    action_detail = dict()
+    action_detail["Previous State"] = get_changes(target)
+
+    listener_types = {
+        "insert": "create",
+        "update": "update",
+        "delete": "delete"
+    }
+
+    action_type = listener_types.get(listener_type, "")
+
+    channel = target.channel if hasattr(target, 'channel') else None
+
+    channel = 'slack' if channel is 'slack' else 'web'
+
+    if listener_type is "insert":
+        action_detail["Current State"] = target_as_dict
+        del action_detail["Previous State"]
+        action_details = stringify_action_detail(user_id, model_name, action_detail, "created")
+
+    if listener_type is "update" and not target_as_dict.get('is_deleted'):
+        action_detail["Current State"] = target_as_dict
+        action_details = stringify_action_detail(user_id, model_name, action_detail, "updated")
+
+    if listener_type is "update" and target_as_dict.get('is_deleted'):
+        action_detail["Soft deleted Entity"] = target_as_dict
+        action_details = stringify_action_detail(user_id, model_name, action_detail, "soft deleted")
+
+    if listener_type is "delete":
+        action_detail["Deleted Entity"] = target_as_dict
+        del action_detail["Previous State"]
+        action_detail["Current State"] = {}
+        action_details = stringify_action_detail(user_id, model_name, action_detail, "hard deleted")
+
+    @event.listens_for(db.session, "after_flush", once=True)
+    def receive_after_flush(session, context):
+
+        session.add(Activity(
+                module_name=model_name,
+                ip_address=ip_address,
+                user_id=user_id,
+                action_type=action_type,
+                action_details=action_details,
+                channel=channel
+            ))
+
+
+def get_changes(target):
+    """Return only changes that have been made on an entry"""
+    state = db.inspect(target)
+    changes = {}
+
+    for attr in state.attrs:
+        hist = state.get_history(attr.key, True)
+        if not hist.has_changes():
+            continue
+
+        # hist.deleted holds old value
+        # hist.added holds new value
+        changes[attr.key] = hist.deleted
+
+    # Extract first value in the list of changed items
+    for key, value in changes.items():
+        if isinstance(value, list) and len(value) > 0:
+            changes[key] = value[0]
+
+    return changes
+
+
+def stringify_action_detail(user_id, model_name, action_detail, action_type):
+    """Convert action detail into a more readable format"""
+    return "{" + user_id + "} " + action_type + " {" + model_name + "}" + " on " + "{" + \
+        dt.today().strftime('%A') + "}" + " " + dt.today().strftime('%Y-%m-%d') + \
+        "\n" + "Body: " + str(action_detail)
+

--- a/tests/unit/models/test_hard_delete_on_model.py
+++ b/tests/unit/models/test_hard_delete_on_model.py
@@ -1,6 +1,6 @@
 from tests.base_test_case import BaseTestCase
 
-from app.models import Vendor
+from app.models import Vendor, Activity
 
 
 class TestHardDelete(BaseTestCase):
@@ -23,4 +23,49 @@ class TestHardDelete(BaseTestCase):
 
         self.assertEquals(Vendor.query.get(vendor_id), None)
 
+    def test_creating_vendor_gets_logged(self):
+        vendor = Vendor(
+            name='Your name',
+            address='Your Address',
+            tel='12345678',
+            contact_person='Contact Person',
+        )
+        vendor.save()
+
+        activity = [activity.action_details for activity in Activity.query.all()]
+
+        self.assertTrue("created" in activity[0])
+
+    def test_updating_vendor_gets_logged(self):
+        vendor = Vendor(
+            name='Your name',
+            address='Your Address',
+            tel='12345678',
+            contact_person='Contact Person',
+        )
+        vendor.save()
+
+        vendor = Vendor.query.get(1)
+        vendor.name = "New Name"
+        vendor.save()
+
+        activity = [activity.action_details for activity in Activity.query.all()]
+
+        self.assertTrue("updated" in activity[1])
+
+    def test_hard_deleting_vendor_gets_logged(self):
+        vendor = Vendor(
+            name='Your name',
+            address='Your Address',
+            tel='12345678',
+            contact_person='Contact Person',
+        )
+        vendor.save()
+
+        vendor = Vendor.query.get(1)
+        vendor.delete()
+
+        activity = [activity.action_details for activity in Activity.query.all()]
+
+        self.assertTrue("hard deleted" in activity[1])
 

--- a/tests/unit/models/test_hard_delete_on_model.py
+++ b/tests/unit/models/test_hard_delete_on_model.py
@@ -1,0 +1,26 @@
+from tests.base_test_case import BaseTestCase
+
+from app.models import Vendor
+
+
+class TestHardDelete(BaseTestCase):
+
+    def setUp(self):
+        self.BaseSetUp()
+
+    def test_hard_delete_on_vendor_model(self):
+        vendor = Vendor(
+            name='Your name',
+            address='Your Address',
+            tel='12345678',
+            contact_person='Contact Person',
+        )
+
+        vendor.save()
+        vendor_id = vendor.id
+
+        vendor.delete()
+
+        self.assertEquals(Vendor.query.get(vendor_id), None)
+
+


### PR DESCRIPTION
**What does this PR do?**
- Add event listeners to the Admin Models

**Description of Task to be completed?**
- Add after_insert, after_update and after_delete event listeners to the models: Vendor, 
    VendorEngagement, MealItem, Menu, Faq, Role, Permission, UserRole, and Location.
- Add after_update and after_delete event listeners to the VendorRating model

**How should this be manually tested?**
1.  Pull the branch `ch-event-listener-vendor-model` locally to your machine.
2. Start the application by running `python run.py runserver`
3. Using the endpoint for any of the Models specified above, create, update and delete any entity.
4. Using a tool such as `pgAdmin` or `postico` open up the table `activities` and you should see a log of any Activity you performed. An illustration of what you may see is below:

![image](https://user-images.githubusercontent.com/17172747/53743682-72a19580-3eac-11e9-8e7b-d3e515c5b406.png)

**Any background context you want to provide?**
- It was not possible to log any activities such as insert, update or delete carried out on any of the models. 

**What are the relevant pivotal tracker stories?**

* [#164267007](https://www.pivotaltracker.com/story/show/164267007)
* [#164240383](https://www.pivotaltracker.com/story/show/164240383)