### PR TITLE
Add endpoints to view activity logs

### DIFF
--- a/app/blueprints/activity_blueprint.py
+++ b/app/blueprints/activity_blueprint.py
@@ -1,0 +1,23 @@
+"""
+Module to deal with Activity logs
+"""
+
+from app.blueprints.base_blueprint import Blueprint, BaseBlueprint, request
+from app.controllers.activity_controller import ActivityController
+from app.utils.security import Security
+
+activity_blueprint = Blueprint('activity', __name__, url_prefix='{}/activities'.format(BaseBlueprint.base_url_prefix))
+activity_controller = ActivityController(request)
+
+
+@activity_blueprint.route('/range', methods=['GET'])
+@Security.url_validator(['date_range|required:range'])
+def list_activities_date_range():
+    return activity_controller.list_by_date_range()
+
+
+@activity_blueprint.route('/action_range', methods=['GET'])
+@Security.url_validator(['action_type|required:exists:', 'date_range|required:range'])
+def list_activities_action_type_date_range():
+    import pdb;pdb.set_trace()
+    return activity_controller.list_by_action_type_and_date_range()

--- a/app/blueprints/activity_blueprint.py
+++ b/app/blueprints/activity_blueprint.py
@@ -1,10 +1,11 @@
 """
 Module to deal with Activity logs
 """
-
+from flasgger import swag_from
 from app.blueprints.base_blueprint import Blueprint, BaseBlueprint, request
 from app.controllers.activity_controller import ActivityController
 from app.utils.security import Security
+
 
 activity_blueprint = Blueprint('activity', __name__, url_prefix='{}/activities'.format(BaseBlueprint.base_url_prefix))
 activity_controller = ActivityController(request)
@@ -12,11 +13,13 @@ activity_controller = ActivityController(request)
 
 @activity_blueprint.route('/range', methods=['GET'])
 @Security.url_validator(['date_range|required:range'])
+@swag_from('documentation/get_activities_by_date.yml')
 def list_activities_date_range():
     return activity_controller.list_by_date_range()
 
 
 @activity_blueprint.route('/action_range', methods=['GET'])
 @Security.url_validator(['action_type|required:enum_options', 'date_range|required:range'])
+@swag_from('documentation/get_activities_by_date_and_action_type.yml')
 def list_activities_action_type_date_range():
     return activity_controller.list_by_action_type_and_date_range()

--- a/app/blueprints/activity_blueprint.py
+++ b/app/blueprints/activity_blueprint.py
@@ -17,7 +17,6 @@ def list_activities_date_range():
 
 
 @activity_blueprint.route('/action_range', methods=['GET'])
-@Security.url_validator(['action_type|required:exists:', 'date_range|required:range'])
+@Security.url_validator(['action_type|required:enum_options', 'date_range|required:range'])
 def list_activities_action_type_date_range():
-    import pdb;pdb.set_trace()
     return activity_controller.list_by_action_type_and_date_range()

--- a/app/blueprints/base_blueprint.py
+++ b/app/blueprints/base_blueprint.py
@@ -27,6 +27,7 @@ class BaseBlueprint:
 		from app.blueprints.user_blueprint import user_blueprint
 		from app.blueprints.faq_blueprint import faq_blueprint
 		from app.blueprints.reports_blueprint import reports_blueprint
+		from app.blueprints.activity_blueprint import activity_blueprint
 		
 		self.app.register_blueprint(meal_item_blueprint)
 		self.app.register_blueprint(vendor_blueprint)
@@ -41,3 +42,4 @@ class BaseBlueprint:
 		self.app.register_blueprint(user_blueprint)
 		self.app.register_blueprint(faq_blueprint)
 		self.app.register_blueprint(reports_blueprint)
+		self.app.register_blueprint(activity_blueprint)

--- a/app/blueprints/documentation/get_activities_by_date.yml
+++ b/app/blueprints/documentation/get_activities_by_date.yml
@@ -1,0 +1,73 @@
+Get All Actvities between two dates
+---
+tags:
+  - Activities
+summary: Get all Activities by Date range
+consumes:
+  - application/json
+parameters:
+  - name: X-Location
+    in: header
+    type: integer
+    required: true
+    description: The location of user
+    default: 1
+  - name: Authorization
+    in: header
+    type: string
+    required: true
+    description: Bearer Token Value
+  - name: date_range
+    in: path
+    type: string
+    required: true
+    description: a range of dates
+    default: "2019-01-01:2019-12-31"
+definitions:
+  GetActivitiesPayload:
+    type: object
+    properties:
+      msg:
+        type: string
+        default: Ok
+      payload:
+        type: object
+        properties:
+          activities:
+            type: array
+            items:
+              type: object
+              properties:
+                moduleName:
+                  type: string
+                ipAddress:
+                  type: string
+                userId:
+                  type: string
+                actionType:
+                  type: string
+                actionDetails:
+                  type: string
+                channel:
+                  type: string
+                id:
+                  type: integer
+                isDeleted:
+                  type: boolean
+                timestamps:
+                  type: object
+                  properties:
+                    created_at:
+                      type: string
+                      format: date
+                      example: 2018-10-22
+                    updated_at:
+                      type: string
+                      format: date
+                      example: 2018-10-22
+
+responses:
+  200:
+    description: Ok
+    schema:
+          $ref: '#/definitions/GetActivitiesPayload'

--- a/app/blueprints/documentation/get_activities_by_date_and_action_type.yml
+++ b/app/blueprints/documentation/get_activities_by_date_and_action_type.yml
@@ -1,0 +1,79 @@
+Get All Actvities between two dates made using a specific action type
+---
+tags:
+  - Activities
+summary: Get all Activities by Date range
+consumes:
+  - application/json
+parameters:
+  - name: X-Location
+    in: header
+    type: integer
+    required: true
+    description: The location of user
+    default: 1
+  - name: Authorization
+    in: header
+    type: string
+    required: true
+    description: Bearer Token Value
+  - name: action_type
+    in: path
+    type: string
+    required: true
+    description: a value corresponding to the existing action types ie. create, update, delete
+    default: "create"
+  - name: date_range
+    in: path
+    type: string
+    required: true
+    description: a range of dates
+    default: "2019-01-01:2019-12-31"
+definitions:
+  GetActivitiesByTypePayload:
+    type: object
+    properties:
+      msg:
+        type: string
+        default: Ok
+      payload:
+        type: object
+        properties:
+          activities:
+            type: array
+            items:
+              type: object
+              properties:
+                moduleName:
+                  type: string
+                ipAddress:
+                  type: string
+                userId:
+                  type: string
+                actionType:
+                  type: string
+                actionDetails:
+                  type: string
+                channel:
+                  type: string
+                id:
+                  type: integer
+                isDeleted:
+                  type: boolean
+                timestamps:
+                  type: object
+                  properties:
+                    created_at:
+                      type: string
+                      format: date
+                      example: 2018-10-22
+                    updated_at:
+                      type: string
+                      format: date
+                      example: 2018-10-22
+
+responses:
+  200:
+    description: Ok
+    schema:
+          $ref: '#/definitions/GetActivitiesByTypePayload'

--- a/app/controllers/activity_controller.py
+++ b/app/controllers/activity_controller.py
@@ -1,0 +1,44 @@
+from app.controllers.base_controller import BaseController
+from app.repositories.activity_repo import ActivityRepo
+from app.utils.enums import ActionType, Channels
+
+
+class ActivityController(BaseController):
+
+    def __init__(self, request):
+        BaseController.__init__(self, request)
+        self.activity_repo = ActivityRepo()
+
+    def list_by_date_range(self):
+        dates = self.request.args['date_range'].split(":")
+
+        start_date, end_date = dates[0], dates[1]
+
+        activities = self.activity_repo.get_range_paginated_options(
+            start_date=start_date, end_date=end_date
+        )
+
+        return self.handle_response(
+            'OK',
+            payload={
+                'activities': self.return_transformed_enum_items(('actionType', 'channel'), activities.items)
+            }
+        )
+
+    def list_by_action_type_and_date_range(self,):
+        action_type = self.request.args['action_type']
+        dates = self.request.args['date_range'].split(":")
+        start_date, end_date = dates[0], dates[1]
+
+        import pdb;pdb.set_trace()
+
+        activities = self.activity_repo.get_range_action_paginated_options(
+            action_type=action_type, start_date=start_date, end_date=end_date
+        )
+
+        return self.handle_response(
+            'OK',
+            payload={
+                'activities': self.return_transformed_enum_items(('actionType', 'channel'), activities.items)
+            }
+        )

--- a/app/controllers/activity_controller.py
+++ b/app/controllers/activity_controller.py
@@ -30,8 +30,6 @@ class ActivityController(BaseController):
         dates = self.request.args['date_range'].split(":")
         start_date, end_date = dates[0], dates[1]
 
-        import pdb;pdb.set_trace()
-
         activities = self.activity_repo.get_range_action_paginated_options(
             action_type=action_type, start_date=start_date, end_date=end_date
         )

--- a/app/controllers/activity_controller.py
+++ b/app/controllers/activity_controller.py
@@ -10,12 +10,10 @@ class ActivityController(BaseController):
         self.activity_repo = ActivityRepo()
 
     def list_by_date_range(self):
-        dates = self.request.args['date_range'].split(":")
-
-        start_date, end_date = dates[0], dates[1]
+        date_ranges = self.get_params('date_range')[0].split(":")
 
         activities = self.activity_repo.get_range_paginated_options(
-            start_date=start_date, end_date=end_date
+            start_date=date_ranges[0], end_date=date_ranges[1]
         )
 
         return self.handle_response(
@@ -25,13 +23,15 @@ class ActivityController(BaseController):
             }
         )
 
-    def list_by_action_type_and_date_range(self,):
-        action_type = self.request.args['action_type']
-        dates = self.request.args['date_range'].split(":")
-        start_date, end_date = dates[0], dates[1]
+    def list_by_action_type_and_date_range(self):
+
+        query_params = self.get_params_dict()
+
+        date_ranges = query_params.get('date_range').split(":")
+        action_type = query_params.get('action_type')
 
         activities = self.activity_repo.get_range_action_paginated_options(
-            action_type=action_type, start_date=start_date, end_date=end_date
+            action_type=action_type, start_date=date_ranges[0], end_date=date_ranges[1]
         )
 
         return self.handle_response(

--- a/app/controllers/base_controller.py
+++ b/app/controllers/base_controller.py
@@ -69,3 +69,25 @@ class BaseController:
 	def prettify_response_dates(self, created_at, updated_at=None):
 		return {'created_at': created_at, 'updated_at': updated_at,
 				'date_pretty_short': created_at.strftime('%b %d, %Y'), 'date_pretty': created_at.strftime('%B %d, %Y')}
+
+	@staticmethod
+	def return_transformed_enum_items(enums, items):
+		"""Transform enum types to strings of returned paginated items
+
+			: param1 target(tuple): A tuple of keys corresponding to dictionary values that are enum types
+			: param2 items(list): A list of items in a paginator
+
+			: return(list): list of transformed items
+		"""
+		transformed_items = []
+
+		for activity in items:
+
+			activity_item = activity.serialize()
+
+			for each_enum in enums:
+				activity_item[each_enum] = activity_item[each_enum].value
+
+			transformed_items.append(activity_item)
+
+		return transformed_items

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,3 +1,4 @@
+from itertools import zip_longest
 from functools import wraps
 from datetime import datetime
 from flask import request, make_response, jsonify
@@ -42,9 +43,25 @@ class Security:
 									jsonify({'msg': 'Bad Request - {} must be integer'.format(request_key)})), 400
 
 							if validator == 'range':
-								elements_compare = arguments[request_key].split(':')
-								first_date = datetime.strptime(str(elements_compare[0]), '%Y-%m-%d')
-								second_date = datetime.strptime(str(elements_compare[1]), '%Y-%m-%d')
+								if ':' in arguments[request_key]:
+									elements_compare = arguments[request_key].split(':')
+								else:
+									return make_response(
+										jsonify(
+											{'msg': 'Bad Request - There must be a `:` separating the dates'}
+										)), 400
+
+								try:
+									first_date = datetime.strptime(str(elements_compare[0]), '%Y-%m-%d')
+									second_date = datetime.strptime(str(elements_compare[1]), '%Y-%m-%d')
+								except Exception as e:
+									return make_response(
+										jsonify({'msg': 'Bad Request - dates {} and {} should be valid dates.\
+											Format: YYYY-MM-DD'.format(
+											str(elements_compare[0]),
+											str(elements_compare[1]))
+										}
+										)), 400
 								if first_date > second_date:
 									return make_response(
 										jsonify({'msg': 'Bad Request - Start Date [{}] must be less than End Date[{}]'

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -3,7 +3,7 @@ from functools import wraps
 from datetime import datetime
 from flask import request, make_response, jsonify
 from app.utils.snake_case import SnakeCaseConversion
-
+from app.utils.enums import ActionType, Channels
 
 class Security:
 
@@ -99,6 +99,26 @@ class Security:
 									return make_response(
 										jsonify({'msg': 'Bad Request - {} can only have a len of {}'.format(
 											request_key, length_value)})), 400
+
+							if validator == 'enum_options':
+								mapper = {
+									'action_type': ActionType,
+									'channels': Channels
+								}
+
+								if not mapper.get(request_key, None):
+									return make_response(
+										jsonify({'msg': 'Bad Request - Invalid search field {}'.format(
+											request_key)})), 400
+
+								if not mapper.get(request_key).has_value(arguments[request_key]):
+									return make_response(
+										jsonify({'msg': 'Bad Request - {} can only have options: {}'.format(
+											request_key,
+											str([item.name for item in mapper.get(request_key)]).strip('[]')
+										)}
+										)
+									), 400
 
 							if validator == 'exists':
 								import importlib

--- a/factories/activity_factory.py
+++ b/factories/activity_factory.py
@@ -1,7 +1,8 @@
-import factory
+import factory, datetime
 from app.utils import db
 from app.models.activity import Activity
 from app.utils.enums import Channels, ActionType
+
 
 
 class ActivityFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -17,4 +18,5 @@ class ActivityFactory(factory.alchemy.SQLAlchemyModelFactory):
     action_type = ActionType.create
     action_details = "Creation of a new item"
     user_id = '-L5J538y77WvOnzJ1FPG'
+    created_at = datetime.datetime.now()
 

--- a/tests/integration/endpoints/test_activity_endpoints.py
+++ b/tests/integration/endpoints/test_activity_endpoints.py
@@ -1,0 +1,178 @@
+from tests.base_test_case import BaseTestCase
+from factories.activity_factory import ActivityFactory
+import datetime
+
+
+class TestActivityEndpoints(BaseTestCase):
+    """Test class for Activity endpoints"""
+
+    def setUp(self):
+        self.BaseSetUp()
+
+    def test_get_range_correct_date_range_succeeds(self):
+
+        activity = ActivityFactory.create()
+
+        create_date = activity.created_at.date()
+        create_date_ahead = activity.created_at.date() + datetime.timedelta(days=3)
+
+        first_date = str(create_date.year) + "-" + \
+                     str(create_date.month).zfill(2) + \
+                     "-" + str(create_date.day).zfill(2)
+
+        second_date = str(create_date_ahead.year) + "-"\
+                      + str(create_date_ahead.month).zfill(2) + "-" + \
+                      str(create_date_ahead.day).zfill(2)
+
+        response = self.client().get(
+            self.make_url("/activities/range"),
+            query_string={'date_range': first_date + ":" + second_date}, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['msg'], 'OK')
+        self.assertEqual(response_json['payload']['activities'][0]['id'], activity.id)
+        self.assertEqual(response_json['payload']['activities'][0]['isDeleted'], activity.is_deleted)
+        self.assertEqual(response_json['payload']['activities'][0]['ipAddress'], activity.ip_address)
+        self.assertEqual(response_json['payload']['activities'][0]['actionType'], activity.action_type)
+        self.assertEqual(response_json['payload']['activities'][0]['actionDetails'], activity.action_details)
+        self.assertEqual(response_json['payload']['activities'][0]['channel'], activity.channel)
+
+    def test_get_range_with_wrong_date_range_order_fails(self):
+
+        activity = ActivityFactory.create()
+
+        create_date = activity.created_at.date()
+        create_date_ahead = activity.created_at.date() + datetime.timedelta(days=3)
+
+        first_date = str(create_date.year) + "-" + \
+                     str(create_date.month).zfill(2) + \
+                     "-" + str(create_date.day).zfill(2)
+
+        second_date = str(create_date_ahead.year) + "-"\
+                      + str(create_date_ahead.month).zfill(2) + "-" + \
+                      str(create_date_ahead.day).zfill(2)
+
+        response = self.client().get(
+            self.make_url("/activities/range"),
+            query_string={'date_range': second_date + ":" + first_date}, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("Bad Request - Start Date", response_json['msg'])
+
+    def test_get_range_with_invalid_dates_fails(self):
+
+        response = self.client().get(
+            self.make_url("/activities/range"),
+            query_string={'date_range': "inndaf" + ":" + "dfaeavd"}, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("should be valid dates", response_json['msg'])
+
+    def test_get_range_incorrect_range_separator_fails(self):
+
+        response = self.client().get(
+            self.make_url("/activities/range"),
+            query_string={'date_range': "inndaf dfaeavd"}, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("Bad Request - There must be a `:` separating the dates", response_json['msg'])
+
+    def test_get_range_no_provision_of_query_params_fails(self):
+
+        response = self.client().get(
+            self.make_url("/activities/range"), headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("Bad Request - Request Must be Properly Formatted", response_json['msg'])
+
+    def test_get_action_range_correct_values_succeeds(self):
+
+        activity = ActivityFactory.create()
+
+        create_date = activity.created_at.date()
+        create_date_ahead = activity.created_at.date() + datetime.timedelta(days=3)
+
+        first_date = str(create_date.year) + "-" + \
+                     str(create_date.month).zfill(2) + \
+                     "-" + str(create_date.day).zfill(2)
+
+        second_date = str(create_date_ahead.year) + "-"\
+                      + str(create_date_ahead.month).zfill(2) + "-" + \
+                      str(create_date_ahead.day).zfill(2)
+
+        response = self.client().get(
+            self.make_url("/activities/action_range"),
+            query_string={
+                'date_range': first_date + ":" + second_date,
+                'action_type': 'create'
+            }, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert200(response)
+        self.assertEqual(response_json['msg'], 'OK')
+        self.assertEqual(response_json['payload']['activities'][0]['id'], activity.id)
+        self.assertEqual(response_json['payload']['activities'][0]['isDeleted'], activity.is_deleted)
+        self.assertEqual(response_json['payload']['activities'][0]['ipAddress'], activity.ip_address)
+        self.assertEqual(response_json['payload']['activities'][0]['actionType'], activity.action_type)
+        self.assertEqual(response_json['payload']['activities'][0]['actionDetails'], activity.action_details)
+        self.assertEqual(response_json['payload']['activities'][0]['channel'], activity.channel)
+
+    def test_get_action_range_invalid_enum_options_fails(self):
+
+        activity = ActivityFactory.create()
+
+        create_date = activity.created_at.date()
+        create_date_ahead = activity.created_at.date() + datetime.timedelta(days=3)
+
+        first_date = str(create_date.year) + "-" + \
+                     str(create_date.month).zfill(2) + \
+                     "-" + str(create_date.day).zfill(2)
+
+        second_date = str(create_date_ahead.year) + "-"\
+                      + str(create_date_ahead.month).zfill(2) + "-" + \
+                      str(create_date_ahead.day).zfill(2)
+
+        response = self.client().get(
+            self.make_url("/activities/action_range"),
+            query_string={
+                'date_range': first_date + ":" + second_date,
+                'action_type': 'insert'  # an invalid enum option
+            }, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("can only have options:", response_json['msg'])
+
+    def test_get_action_range_required_query_param_not_supplied_fails(self):
+
+        response = self.client().get(
+            self.make_url("/activities/action_range"),
+            query_string={
+                'date_range': '2019-01-01' + ":" + '2019-10-10',
+                'action_typq': 'insert'  # Supplying a non existing query parameter ie action_typq
+            }, headers=self.headers()
+        )
+
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assert400(response)
+        self.assertIn("Bad Request - action_type is required", response_json['msg'])

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -349,3 +349,15 @@ class TestSecurity(BaseTestCase):
             response = Security.validate_query_params(Faq)(lambda *args, **kwargs: ('test',))()
 
         self.assertEqual(response, ('test',))
+
+    def test_validator_validates_for_non_enum_required_and_non_existing_enum(self):
+        class MockRequest:
+            args = {
+                'action_typ': 'create'
+            }
+
+        with patch('app.utils.security.request', new_callable=MockRequest):
+            response = Security.url_validator(['action_typ|enum_options'])(lambda *args, **kwargs: ('test',))()
+
+        self.assertIn(
+            'Bad Request - Invalid search field', response[0].get_json()['msg'])


### PR DESCRIPTION
**What does this PR do?**
- Adds endpoints that enable the viewing of activity logs

**Description of Task to be completed?**
- Create endpoint `api/v1/activities/range` that enables the viewing of all activities between certain two dates by specifying a query parameter `date_range=2019-01-30:2019-02-30`
- Create endpoint `api/v1/activities/action_range` that enables the viewing of all activities between certain two dates by specifying two query parameters. An example form is `date_range=2019-01-30:2019-02-30&action_type=create`
- Add documentation for the endpoints

**How should this be manually tested?**
- Pull the branch `ch-add-activity-blueprint-and-controllers-164240383` and checkout to it.
- Try to create a couple of vendors
- Try to access the endpoints above by specifying the date ranges and the action type required. You should be able to get a list of activity logs

**Any background context you want to provide?**
- There was no endpoint to view the activity logs. This pull request creates those endpoints

**What are the relevant pivotal tracker stories?**
[#164240383](https://www.pivotaltracker.com/story/show/164240383)