### PR TITLE
Add 'Roles' property to the result of fetching admin users

### DIFF
--- a/app/blueprints/documentation/get_all_admin_users.yml
+++ b/app/blueprints/documentation/get_all_admin_users.yml
@@ -37,6 +37,15 @@ definitions:
                   type: string
                 Name:
                   type: string
+                Roles:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
 responses:
   200:
     description: Ok


### PR DESCRIPTION
**What does this PR do?**

* add `Roles` property to the result of fetching all admin users

**Description of Task to be completed?**
* refactor the controller to add `Roles` property
* update the endpoint documentation
* fix failing tests
**How should this be manually tested?**
* pull the branch `update-fetch-admin-users` and checkout to the branch
* send a get request to `http://localhost:5000/api/v1/users/admin`. If you have the appropriate permission, you will receive a success response, showing the admin users. For each user, a list of their roles is also attached.
**Any background context you want to provide?**

**What are the relevant pivotal tracker stories?**
[Update [GET]users/admin endpoint](https://www.pivotaltracker.com/story/show/164490677)

**Sample screenshot**
![image](https://user-images.githubusercontent.com/24465059/54119898-c5240a00-43f6-11e9-804d-29e6e4ae6b54.png)


