### PR TITLE
#158863653 Generate summary report for dashboard

### DIFF
--- a/app/blueprints/documentation/get_report.yml
+++ b/app/blueprints/documentation/get_report.yml
@@ -1,9 +1,10 @@
 
-Get Dashboard Report
+Returns statistics of collected, uncollected and cancelled orders for any number of days. It takes two dates and return report between the two days. If the dates are not specified, it returns report for the last 14 days. If the query parameter all_vendor_comparison=true is used, it returns the report on per vendor basis
 ---
 tags:
   - Reports
-summary: Get reports for the dashboard
+summary: >
+          Get reports for the dashboard.
 parameters:
   - name: X-Location
     in: header
@@ -16,12 +17,24 @@ parameters:
     type: string
     required: true
     description: Bearer Token Value
-  - name: period
+  - name: start_date
     in: path
-    type: integer
+    type: string
+    format: date
     required: false
-    description: the number of days the report should span
-    default: 14
+    description: the start date for the report
+  - name: end_date
+    in: path
+    type: string
+    format: date
+    required: false
+    description: the end date for the report
+  - name: all_vendor_comparison
+    in: path
+    type: string
+    required: false
+    description: used to indicate that report for all vendors be retrieved
+    default: true
 definitions:
   ReportPayload:
     type: object

--- a/app/controllers/reports_controller.py
+++ b/app/controllers/reports_controller.py
@@ -2,9 +2,10 @@
 """
 from datetime import datetime, timedelta
 import pandas as pd
+from sqlalchemy import and_
 from app.controllers.base_controller import BaseController
-from app.repositories import OrderRepo, VendorRatingRepo, VendorEngagementRepo
-from app.models import Order
+from app.repositories import OrderRepo, VendorRatingRepo, VendorEngagementRepo, VendorRepo
+from app.models import Order, Menu
 
 
 class ReportsController(BaseController):
@@ -13,17 +14,46 @@ class ReportsController(BaseController):
         self.rating_repo = VendorRatingRepo()
         self.order_repo = OrderRepo()
         self.engagement_repo = VendorEngagementRepo()
+        self.vendor_repo = VendorRepo()
 
     def dashboard_summary(self):
         params = self.get_params_dict()
-        period = int(params.get('period', 14))
-        last_date = datetime.now().date() - timedelta(period)
 
-        orders = Order.query.filter(Order.date_booked_for >= last_date)
+        if 'all_vendor_comparison' in params:
+            orders = self.order_repo.fetch_all()
+            vendors = self.vendor_repo.get_unpaginated(is_deleted=False)
+            vendor_orders = []
+            for vendor in vendors:
+                vendor_info = {}
+                vendor_info['id'] = vendor.id
+                vendor_info['name'] = vendor.name
+                vendor_info['collectedOrders'] = len([order for order in orders.items if
+                                                    order.order_status == 'collected' and Menu.query.get(
+                                                        order.menu_id).vendor_engagement.vendor_id == vendor.id])
+                vendor_info['uncollectedOrders'] = len([order for order in orders.items if
+                                                     order.order_status == 'booked' and Menu.query.get(
+                                                         order.menu_id).vendor_engagement.vendor_id == vendor.id])
+                vendor_info['cancelledOrders'] = len([order for order in orders.items if
+                                                      order.order_status == 'cancelled' and Menu.query.get(
+                                                          order.menu_id).vendor_engagement.vendor_id == vendor.id])
+                vendor_orders.append(vendor_info)
+
+            return self.handle_response('ok', payload=vendor_orders)
+
+        str_start_date = params.get('start_date')
+        start_date = datetime.now().date() if str_start_date is None else datetime.strptime(str_start_date, '%Y-%m-%d').date()
+
+        str_end_date = params.get('end_date')
+        end_date = (datetime.now().date() - timedelta(14)) if str_end_date is None else datetime.strptime(str_end_date, '%Y-%m-%d').date()
+
+        if start_date < end_date:
+            return self.handle_response('Start date must not be less than end date', status_code=400)
+
+        orders = Order.query.filter(and_(Order.date_booked_for >= end_date, Order.date_booked_for <= start_date))
         orders_collected = [order for order in orders if order.order_status == 'collected']
         orders_cancelled = [order for order in orders if order.order_status == 'cancelled']
         orders_uncollected = [order for order in orders if order.order_status == 'booked']
-        dates = [date.date() for date in pd.bdate_range(last_date, datetime.now().date())]
+        dates = [date.date() for date in pd.bdate_range(end_date, start_date)]
         result = []
 
         for date in dates:

--- a/tests/integration/endpoints/test_reports_endpoint.py
+++ b/tests/integration/endpoints/test_reports_endpoint.py
@@ -1,7 +1,6 @@
 import datetime
 from tests.base_test_case import BaseTestCase
-from factories import VendorRatingFactory
-
+from factories import OrderFactory, VendorRatingFactory, VendorFactory, VendorEngagementFactory, MenuFactory
 
 class TestReportsEndpoints(BaseTestCase):
 
@@ -11,12 +10,40 @@ class TestReportsEndpoints(BaseTestCase):
     def test_report(self):
         recent_date = datetime.datetime.now().date() + datetime.timedelta(7)
 
-        ratings = VendorRatingFactory.create_batch(3, service_date=recent_date)
+        VendorRatingFactory.create_batch(3, service_date=recent_date)
         response = self.client().get(self.make_url('/reports/'), headers=self.headers())
         response_json = self.decode_from_json_string(response.data.decode('utf-8'))
         payload = response_json['payload']
 
         self.assertEqual(response.status_code, 200)
         self.assertJSONKeyPresent(response_json, 'payload')
-        self.assertJSONKeyPresent(response_json['payload'][0], 'vendor')
         self.assertEqual(type(payload), list)
+
+    def test_report_fails_for_start_date_less_than_endDate(self):
+        recent_date = datetime.datetime.now().date() + datetime.timedelta(7)
+
+        VendorRatingFactory.create_batch(3, service_date=recent_date)
+        response = self.client().get(self.make_url('/reports/?start_date=2019-03-10&end_date=2019-03-12'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_json['msg'], 'Start date must not be less than end date')
+
+    def test_all_vendor_comparison(self):
+        vendor = VendorFactory.create()
+        engagement = VendorEngagementFactory.create(vendor_id=vendor.id)
+        menu = MenuFactory.create(vendor_engagement_id=engagement.id)
+        OrderFactory.create(menu_id=menu.id)
+        OrderFactory.create(menu_id=menu.id - 1)
+
+        recent_date = datetime.datetime.now().date() + datetime.timedelta(7)
+
+        VendorRatingFactory.create_batch(3, service_date=recent_date)
+        response = self.client().get(self.make_url('/reports/?all_vendor_comparison=true'), headers=self.headers())
+        response_json = self.decode_from_json_string(response.data.decode('utf-8'))
+        payload = response_json['payload']
+
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONKeyPresent(response_json, 'payload')
+        self.assertEqual(type(payload), list)
+


### PR DESCRIPTION
**What does this PR do?**

* Creates the endpoint for dashboard report

**Description of Task to be completed?**
* add the endpoint that returns the rating and order information for a given period
* Add documentation for the endpoint
**How should this be manually tested?**
* pull the branch `all-vendors-report` and checkout to the branch
* send  `get` request to `localhost:5000/api/v1/reports/` 
You will get the report for the past 14 days, by default. To customize the number of days, add the `?start_date=x&`?`end_date=y` to the url, where`x`  and `y` are dates in format`YYYY-MM-dd`. You can also add the query parameter `all_vendors_comparison=true` to get the report for all vendors for all times

**Any background context you want to provide?**

**What are the relevant pivotal tracker stories?**
[158863653](https://www.pivotaltracker.com/story/show/158863653)

**Sample screenshot
![image](https://user-images.githubusercontent.com/24465059/54624408-9698d580-4a6d-11e9-98a2-da365fd9c43f.png)

