### PR TITLE
#164831637 change the name of the admin role

### DIFF
--- a/app/blueprints/about_blueprint.py
+++ b/app/blueprints/about_blueprint.py
@@ -3,7 +3,7 @@ Module to deal with the about page
 """
 from flasgger import swag_from
 
-from app.blueprints.base_blueprint import Blueprint, BaseBlueprint, request
+from app.blueprints.base_blueprint import Blueprint, BaseBlueprint, request, Auth
 from app.controllers.about_controller import AboutController
 from app.utils.security import Security
 
@@ -19,6 +19,7 @@ def get_about_page():
 
 
 @about_blueprint.route('/create_or_update', methods=['POST', 'PATCH'])
+@Auth.has_role('admin')
 @Security.validator(['data|required'])
 @swag_from('documentation/create_about.yml')
 def create_about_page():

--- a/app/blueprints/faq_blueprint.py
+++ b/app/blueprints/faq_blueprint.py
@@ -22,7 +22,7 @@ def list_faqs():
 
 
 @faq_blueprint.route('/', methods=['POST'])
-@Auth.has_role('Administrator')
+@Auth.has_role('admin')
 @Security.validator(['category|required:enum_FaqCategoryType', 'question|required', 'answer|required'])
 @swag_from('documentation/create_faq.yml')
 def create_faq():
@@ -31,7 +31,7 @@ def create_faq():
 
 
 @faq_blueprint.route('/<int:faq_id>', methods=['PUT', 'PATCH'])
-@Auth.has_role('Administrator')
+@Auth.has_role('admin')
 @Security.validator(['category|optional:enum_FaqCategoryType', 'question|optional', 'answer|optional'])
 @swag_from('documentation/update_faq.yml')
 def update_faq(faq_id):
@@ -40,7 +40,7 @@ def update_faq(faq_id):
 
 
 @faq_blueprint.route('/<int:faq_id>', methods=['DELETE'])
-@Auth.has_role('Administrator')
+@Auth.has_role('admin')
 @swag_from('documentation/delete_faq.yml')
 def delete_faq(faq_id):
 

--- a/app/utils/seeders/seed_data.py
+++ b/app/utils/seeders/seed_data.py
@@ -5,7 +5,7 @@ location_data = [
     {'id': '4', 'name': 'Kigali', 'zone': "+3"},
 ]
 role_data = [
-    {'id': '1', 'name': 'Administrator'},
+    {'id': '1', 'name': 'admin'},
     {'id': '2', 'name': 'user'},
 ]
 

--- a/tests/integration/endpoints/test_about_endpoint.py
+++ b/tests/integration/endpoints/test_about_endpoint.py
@@ -1,6 +1,8 @@
 import base64
 from tests.base_test_case import BaseTestCase
 from factories.about_factory import AboutFactory
+from factories.role_factory import RoleFactory
+from factories.user_role_factory import UserRoleFactory
 
 
 class TestAboutEndpoint(BaseTestCase):
@@ -20,6 +22,10 @@ class TestAboutEndpoint(BaseTestCase):
         made in case details do not already exist in the database
         :return: None
         """
+        new_role = RoleFactory.create(name='admin')
+
+        UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
+
         response = self.client().post(
             self.make_url("/about/create_or_update"), headers=self.headers(),
             data=self.encode_to_json_string(self.html_data)
@@ -37,6 +43,10 @@ class TestAboutEndpoint(BaseTestCase):
         made.
         :return: None
         """
+        new_role = RoleFactory.create(name='admin')
+
+        UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
+
         AboutFactory.create(
             details=base64.b64encode(self.html_data['data'].encode('utf-8'))
         )
@@ -94,6 +104,10 @@ class TestAboutEndpoint(BaseTestCase):
         Test that the endpoint '/about/create_or_update' rejects json request without data field
         :return: None
         """
+        new_role = RoleFactory.create(name='admin')
+
+        UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
+
         response = self.client().post(
             self.make_url("/about/create_or_update"), headers=self.headers(),
             data=self.encode_to_json_string(self.html_data_wrong_key)

--- a/tests/integration/endpoints/test_faq_enpoints.py
+++ b/tests/integration/endpoints/test_faq_enpoints.py
@@ -24,7 +24,7 @@ class TestFaqEndpoints(BaseTestCase):
 
     def test_create_faq_succeeds(self):
 
-        new_role = RoleFactory.create(name='Administrator')
+        new_role = RoleFactory.create(name='admin')
 
         new_user_role = UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
 
@@ -43,7 +43,7 @@ class TestFaqEndpoints(BaseTestCase):
         self.assertEqual(response_json['payload']['faq']['answer'], faq.answer)
 
     def test_update_faq_succeeds(self):
-        new_role = RoleFactory.create(name='Administrator')
+        new_role = RoleFactory.create(name='admin')
 
         new_user_role = UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
 
@@ -68,7 +68,7 @@ class TestFaqEndpoints(BaseTestCase):
 
     def test_delete_faq_succeeds(self):
 
-        new_role = RoleFactory.create(name='Administrator')
+        new_role = RoleFactory.create(name='admin')
 
         new_user_role = UserRoleFactory.create(user_id=self.user_id(), role_id=new_role.id)
 


### PR DESCRIPTION
**What does this PR do?**
* change the name of the admin role from "Administrator" to "admin"
* protect the create about endpoint
* update tests

**Description of Task to be completed?**
* change the name of the admin role from "Administrator" to "admin"
* protect the create about endpoint
* update tests

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin bg-fix-admin-naming-164831637 && git checkout bg-fix-admin-naming-164831637`
* Run tests `pytest --cov=app/`
* The `FAQ` and `About` endpoints must be protected

**Any background context you want to provide?**

* N/A.

**What are the relevant pivotal tracker stories?**

* [164831637](https://www.pivotaltracker.com/story/show/164831637) 
 