### PR TITLE
Average rating nullable

### DIFF
--- a/app/models/vendor.py
+++ b/app/models/vendor.py
@@ -9,7 +9,7 @@ class Vendor(BaseModel):
 	tel = db.Column(db.String(20), nullable=False)
 	contact_person = db.Column(db.String(120), nullable=False)
 	is_active = db.Column(db.Boolean, default=True, nullable=True)
-	average_rating = db.Column(db.Float, default=0.0, nullable=False)
+	average_rating = db.Column(db.Float, default=0.0, nullable=True)
 	location_id = db.Column(db.Integer(), db.ForeignKey('locations.id'), default=1)
 	location = db.relationship('Location', lazy=False)
 	engagements = db.relationship('VendorEngagement', lazy=True)


### PR DESCRIPTION
What does this PR do?
- Allow nullable average_rating.

Description of Task to be completed?
- Vendor records that already exist should have null values.

How should this be manually tested?
- N/A

Any background context you want to provide?
- Records that already exists for vendors should not be affected by the change.

What are the relevant pivotal tracker stories?
- 164657450