### PR TITLE
#164890643 Update vendor average rating after every rating

### DIFF
--- a/app/controllers/vendor_rating_controller.py
+++ b/app/controllers/vendor_rating_controller.py
@@ -62,6 +62,7 @@ class VendorRatingController(BaseController):
 
             rating = self.vendor_rating_repo.new_rating(vendor_id, user_id, rating, service_date, RatingType.engagement,
                         engagement_id, engagement_id, channel, comment)
+            self.vendor_repo.update_vendor_average_rating(vendor_id)
             rtng = rating.serialize()
 
             return self.handle_response('Rating created', payload={'rating': rtng}, status_code=201)
@@ -103,6 +104,8 @@ class VendorRatingController(BaseController):
         rating = self.vendor_rating_repo.new_rating(
                     vendor_id, user_id, rating, datetime.strptime(service_date, '%Y-%m-%d'), rating_type, type_id, engagement_id, channel, comment, type_id
                 )
+
+        self.vendor_repo.update_vendor_average_rating(vendor_id)
         if rating.id and rating_type == RatingType.order:
             updates = {'has_rated': True}
             self.order_repo.update(order, **updates)

--- a/app/repositories/vendor_repo.py
+++ b/app/repositories/vendor_repo.py
@@ -1,5 +1,5 @@
 from app.repositories.base_repo import BaseRepo
-from app.models.vendor import Vendor
+from app.models import Vendor, VendorRating
 
 
 class VendorRepo(BaseRepo):
@@ -11,3 +11,12 @@ class VendorRepo(BaseRepo):
 		vendor = Vendor(name=name, address=address, tel=tel, is_active=is_active, contact_person=contact_person, location_id=location_id)
 		vendor.save()
 		return vendor
+
+	def update_vendor_average_rating(self, vendor_id):
+		vendor_ratings = VendorRating.query.filter_by(vendor_id=vendor_id).all()
+		vendor = self.get(vendor_id)
+		rating_values = [rating.rating for rating in vendor_ratings]
+		rating_sum = sum(rating_values)
+		average = round(rating_sum / len(rating_values), 1)
+		self.update(vendor, average_rating=average)
+		return average

--- a/tests/unit/controllers/test_vendor_rating_controller.py
+++ b/tests/unit/controllers/test_vendor_rating_controller.py
@@ -182,6 +182,7 @@ class TestVendorRatingController(BaseTestCase):
             assert result.status_code == 400
             assert result.get_json()['msg'] == 'Invalid vendor_id provided'
 
+    @patch.object(VendorRepo, 'update_vendor_average_rating')
     @patch.object(VendorRatingRepo, 'new_rating')
     @patch.object(VendorEngagementRepo, 'get')
     @patch.object(VendorRatingController, 'request_params')
@@ -193,7 +194,8 @@ class TestVendorRatingController(BaseTestCase):
         mock_auth_user,
         mock_vendor_rating_controller_request_params,
         mock_vendor_engagement_repo_get,
-        mock_vendor_rating_repo_new_rating
+        mock_vendor_rating_repo_new_rating,
+        mock_vendor_rating_repo_update_vendor_average_rating
     ):
         '''Test create_vendor_rating OK response.
         '''
@@ -240,6 +242,7 @@ class TestVendorRatingController(BaseTestCase):
             vendor_rating_controller = VendorRatingController(
                 self.request_context
             )
+            mock_vendor_rating_repo_update_vendor_average_rating.return_value = None
 
             # Act
             result = vendor_rating_controller.create_vendor_rating()
@@ -550,6 +553,7 @@ class TestVendorRatingController(BaseTestCase):
             assert result.get_json()['msg'] == 'You have already rated' \
                 ' this meal'
 
+    @patch.object(VendorRepo, 'update_vendor_average_rating')
     @patch.object(OrderRepo, 'get')
     @patch.object(VendorRatingController, 'request_params')
     @patch('app.Auth.user')
@@ -561,7 +565,8 @@ class TestVendorRatingController(BaseTestCase):
         mock_meal_item_repo_get,
         mock_auth_user,
         mock_vendor_rating_controller_request_params,
-        mock_order_repo_get
+        mock_order_repo_get,
+        mock_vendor_repo_update_average_rating
     ):
         '''Test create_order_rating when order has already been rated.
         '''
@@ -613,6 +618,7 @@ class TestVendorRatingController(BaseTestCase):
             vendor_rating_controller = VendorRatingController(
                 self.request_context
             )
+            mock_vendor_repo_update_average_rating.return_value = None
 
             # Act
             result = vendor_rating_controller.create_order_rating()

--- a/tests/unit/repositories/test_vendor_repo.py
+++ b/tests/unit/repositories/test_vendor_repo.py
@@ -1,7 +1,7 @@
 from tests.base_test_case import BaseTestCase
-from app.models.vendor import Vendor
-from app.repositories.vendor_repo import VendorRepo
-from factories.vendor_factory import VendorFactory
+from app.models import Vendor
+from app.repositories import VendorRepo, VendorRatingRepo
+from factories import VendorFactory, VendorRatingFactory
 
 
 class TestVendorRepo(BaseTestCase):
@@ -9,6 +9,7 @@ class TestVendorRepo(BaseTestCase):
 	def setUp(self):
 		self.BaseSetUp()
 		self.repo = VendorRepo()
+		self.rating_repo = VendorRatingRepo()
 		
 	def test_new_vendor_method_returns_new_vendor_object(self):
 		vendor = VendorFactory.build()
@@ -20,4 +21,17 @@ class TestVendorRepo(BaseTestCase):
 		self.assertEqual(vendor.address, new_vendor.address)
 		self.assertEqual(vendor.contact_person, new_vendor.contact_person)
 		self.assertIsNot(new_vendor.id, 0)
-		
+
+	def test_update_vendor_rating(self):
+		vendor = VendorFactory.build()
+		new_vendor = self.repo.new_vendor(vendor.name, vendor.address, vendor.tel, vendor.is_active, vendor.contact_person, vendor.location_id)
+
+		vendor_rating = VendorRatingFactory.build()
+		self.rating_repo.new_rating(new_vendor.id, vendor_rating.user_id, 4,
+												 vendor_rating.service_date, vendor_rating.rating_type,
+												 vendor_rating.type_id, vendor_rating.engagement_id,
+												 vendor_rating.channel, vendor_rating.comment)
+
+		self.repo.update_vendor_average_rating(new_vendor.id)
+
+		self.assertEqual(new_vendor.average_rating, 4)


### PR DESCRIPTION
**What does this PR do?**
* Automatically updates vendor average rating

**Description of Task to be completed?**
* update the rating creation endpoints to automatically update vendor average rating
* add tests for the affected repo
* add tests for the affected controller

**How should this be manually tested?**
* pull the branch `164890643-vendor-avg-rating` and checkout to the branch
* send  `get` request to `localhost:5000/api/v1/vendors/` The returned vendors have average rating field
**Any background context you want to provide?**
 N/A

**What are the relevant pivotal tracker stories?**
[164890643](https://www.pivotaltracker.com/story/show/164890643)


**Sample screenshot
![image](https://user-images.githubusercontent.com/24465059/55020732-b98c3200-4ff7-11e9-91d2-3cc2ed124b43.png)

