### PR TITLE
#1646799874 Add endpoint to delete user

### DIFF
--- a/app/blueprints/documentation/delete_user.yml
+++ b/app/blueprints/documentation/delete_user.yml
@@ -1,0 +1,43 @@
+Delete a User
+---
+tags:
+  - Users
+summary: Deletes a user with a given id. The id here is the auto-incremented primary key and not the column user_id
+consumes:
+  - application/json
+parameters:
+  - name: X-Location
+    in: header
+    type: integer
+    required: true
+    description: The id of the location
+    default: 1
+  - name: Authorization
+    in: header
+    type: string
+    required: true
+    description: Bearer Token Value
+  - name: id
+    in: path
+    type: integer
+    required: true
+    description: Id of the user to be deleted
+responses:
+  200:
+    description: Ok
+    schema:
+          $ref: '#/definitions/StatusPayload'
+
+definitions:
+  UserPayload:
+    type: object
+    properties:
+      msg:
+        type: string
+        default: user deleted
+      payload:
+        type: object
+        properties:
+          status:
+            type: string
+            default: success

--- a/app/blueprints/user_blueprint.py
+++ b/app/blueprints/user_blueprint.py
@@ -18,3 +18,10 @@ def list_admin_users():
 @swag_from('documentation/get_all_users.yml')
 def list_all_users():
     return user_controller.list_all_users()
+
+
+@user_blueprint.route('/<int:id>/', methods=['DELETE'])
+@Auth.has_permission('delete_user')
+@swag_from('documentation/delete_user.yml')
+def delete_user(id):
+    return user_controller.delete_user(id)

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -83,3 +83,18 @@ class UserController(BaseController):
             return self.handle_response('OK', payload={'users': user_list, 'meta': self.pagination_meta(users)})
         return self.handle_response('No users found', status_code=404)
 
+    def delete_user(self, id):
+        user = self.user_repo.get(id)
+        if user:
+            if user.is_deleted:
+                return self.handle_response('User has already been deleted', status_code=400)
+
+            updates = {}
+            updates['is_deleted'] = True
+
+            self.user_repo.update(user, **updates)
+
+            return self.handle_response('User deleted', payload={"status": "success"})
+        return self.handle_response('Invalid or incorrect id provided', status_code=404)
+
+


### PR DESCRIPTION
**What does this PR do?**
* Add endpoint to delete user

**Description of Task to be completed?**
* add the endpoint to enable authorised user delete a user
* add tests for the affected repo
* add tests for the affected controller
* add PAI documentation for the endpoint

**How should this be manually tested?**
* pull the branch `164945305-add-auto-reminder` and checkout to the branch
* add sample users to the database
* send  `delete` request to `localhost:5000/api/v1/users/{id}. 
**Any background context you want to provide?**
 N/A

**What are the relevant pivotal tracker stories?**
[164679874](https://www.pivotaltracker.com/story/show/164679874)


**Sample screenshot

