### PR TITLE
#165528676 Remove breakfast option completely from slack bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
 
-      - image: redis:5.0.2
+      - image: redis
 
     working_directory: ~/andelaeatapi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           POSTGRES_DB: circle_test
           POSTGRES_PASSWORD: ""
 
-      - image: redis
+      - image: redis:4.0.14
 
     working_directory: ~/andelaeatapi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
       - image: circleci/python:3.6.1
         environment:
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
-          REDIS_DB: 0
+#          REDIS_HOST: localhost
+#          REDIS_PORT: 6379
+#          REDIS_DB: 0
           ANDELA_API_TOKEN: "89S07r4pQ1yTQIQTxfyvHhwPyfDpFg"
           API_AUTH_URL: http://api-staging.andela.com/api/v1
           FLASK_APP: run

--- a/app/controllers/bot_controller.py
+++ b/app/controllers/bot_controller.py
@@ -144,8 +144,8 @@ class BotController(BaseController):
             location_id = payload_action_value.split('_')[1]
 
             period_buttons = [
-                {'name': 'meal_period', 'type': 'button', 'text': 'Breakfast',
-                 'value': 'breakfast_{}'.format(payload_action_value)},
+                # {'name': 'meal_period', 'type': 'button', 'text': 'Breakfast',
+                #  'value': 'breakfast_{}'.format(payload_action_value)},
                 {'name': 'meal_period', 'type': 'button', 'text': 'Lunch',
                  'value': 'lunch_{}'.format(payload_action_value)}
             ]


### PR DESCRIPTION
**What does this PR do?**
* Removes the breakfast option from the slack bot

**Description of Task to be completed?**
* Comment out the code block responsible for displaying the breakfast option.

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin ch-remove-breakfast-option-in-slack-bot-165528676 && git checkout ch-remove-breakfast-option-in-slack-bot-165528676`
* Download ngrok and configure the IP address it generates on your machine to be used with slack.(You may need to ask the TTL for access to the slack web interface to make the changes)
* Start the /testandelaeats application on slack and try to follow the prompts. You should not be able to see the breakfast option

**Any background context you want to provide?**
 N/A

**What are the relevant pivotal tracker stories?**
[165528676](https://www.pivotaltracker.com/story/show/165528676)