### PR TITLE
#166577810 implement query parsing on ratings endpoint

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,22 +29,7 @@
         "JWT_PUBLIC_KEY_STAGING": {
             "required": true
         },
-        "REDIS_DB": {
-            "required": true
-        },
-        "REDIS_HOST": {
-            "required": true
-        },
-        "REDIS_PASSWORD": {
-            "required": true
-        },
-        "REDIS_PORT": {
-            "required": true
-        },
         "REDIS_URL": {
-            "required": true
-        },
-        "REDIS_USER": {
             "required": true
         },
         "SECRET_KEY": {

--- a/app/blueprints/documentation/create_user.yml
+++ b/app/blueprints/documentation/create_user.yml
@@ -25,13 +25,13 @@ parameters:
       required:
         - firstName
         - lastName
-        - userTypeId
+        - roleId
       properties:
         slackId:
           type: string
         firstName:
           type: string
-        userTypeId:
+        roleId:
           type: string
         lastName:
           type: string
@@ -77,7 +77,7 @@ definitions:
                     type: string
                     format: date
                     example: 2018-10-22
-              userType:
+              userRoles:
                 type: object
                 properties:
                   id:

--- a/app/blueprints/documentation/get_all_meal_items.yml
+++ b/app/blueprints/documentation/get_all_meal_items.yml
@@ -29,6 +29,12 @@ parameters:
     required: optional
     description: The number of records per page
     default: 1
+  - name: name
+    in: query
+    required: false
+    description: filter results by meal name
+    example: Bread
+    default: Bread
 definitions:
   MenuItemsPayload:
     type: object

--- a/app/blueprints/documentation/update_user.yml
+++ b/app/blueprints/documentation/update_user.yml
@@ -22,9 +22,6 @@ parameters:
     description: Creation of an User
     schema:
       type: object
-      required:
-        - firstName
-        - lastName
       properties:
         slackId:
           type: string
@@ -33,6 +30,8 @@ parameters:
         lastName:
           type: string
         userId:
+          type: string
+        roleId:
           type: string
         imageUrl:
           type: string

--- a/app/blueprints/meal_item_blueprint.py
+++ b/app/blueprints/meal_item_blueprint.py
@@ -1,5 +1,6 @@
 from app.blueprints.base_blueprint import Blueprint, BaseBlueprint, Security, request, Auth
 from app.controllers.meal_item_controller import MealItemController
+from app.models import MealItem
 from flasgger import swag_from
 
 url_prefix = '{}/meal-items'.format(BaseBlueprint.base_url_prefix)
@@ -9,6 +10,7 @@ meal_item_controller = MealItemController(request)
 
 @meal_item_blueprint.route('/', methods=['GET'])
 @Auth.has_permission('view_meal_item')
+@Security.validate_query_params(MealItem)
 @swag_from('documentation/get_all_meal_items.yml')
 def list_meals():
 	return meal_item_controller.list_meals()

--- a/app/controllers/meal_item_controller.py
+++ b/app/controllers/meal_item_controller.py
@@ -11,11 +11,13 @@ class MealItemController(BaseController):
         self.meal_repo = MealItemRepo()
     
     def list_meals(self):
+        query_kwargs = self.get_params_dict()
         location_id = Auth.get_location()
         meals = self.meal_repo.get_unpaginated_asc(
             self.meal_repo._model.name,
             is_deleted=False,
-            location_id=location_id
+            location_id=location_id,
+            **query_kwargs
         )
         meals_list = [meal.serialize() for meal in meals]
         return self.handle_response('OK', payload={'mealItems': meals_list})

--- a/tests/unit/controllers/test_meal_item_controller.py
+++ b/tests/unit/controllers/test_meal_item_controller.py
@@ -34,12 +34,14 @@ class TestMealItemController(BaseTestCase):
             location_id=1
         )
 
+    @patch.object(MealItemController, 'get_params_dict')
     @patch.object(MealItemRepo, 'get_unpaginated')
     @patch('app.Auth.get_location')
     def test_list_meals_ok_response(
         self,
         mock_get_location,
-        mock_get_unpaginated
+        mock_get_unpaginated,
+        mock_get_params_dict
     ):
         '''Test list_meals OK response.
         '''
@@ -47,6 +49,7 @@ class TestMealItemController(BaseTestCase):
         with self.app.app_context():
             mock_get_location.return_value = 1
             mock_get_unpaginated.return_value = [self.mock_meal_item, ]
+            mock_get_params_dict.return_value = {}
             meal_item_controller = MealItemController(self.request_context)
 
             # Act


### PR DESCRIPTION
**What does this PR do?**
* Implement query parsing on ratings endpoint

**Description of Task to be completed?**
* add query parser to meal-item endpoint

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin ch-query-parser-meal-items-166577810 && ch-query-parser-meal-items-166577810`
* Start  the virtual environment `source venv/bin/activate`
* run tests `pytest`
* start the server `flask run`
* Hit the endpoint `GET {{base-url}}/api/v1/meal-items`, it should support query parsing e.g `{{base-url}}/api/v1/meal-items?name=testname`

**Any background context you want to provide?**
* N/A

**What are the relevant pivotal tracker stories?**
* [166577810](https://www.pivotaltracker.com/story/show/166577810)  