### PR TITLE
Bg fix get admin userendpoint 166755081

### DIFF
--- a/app/controllers/role_controller.py
+++ b/app/controllers/role_controller.py
@@ -85,7 +85,9 @@ class RoleController(BaseController):
 				user_role = self.user_role_repo.new_user_role(
 					role_id=role_id, user_id=user_id,
 					location_id=location, email=email_address)
-				return self.handle_response('OK', payload={'user_role': user_role.serialize()}, status_code=201)
+				user_role_data = user_role.serialize()
+				user_role_data.update({'name': user.get('name')})
+				return self.handle_response('OK', payload={'user_role': user_role_data}, status_code=201)
 			return self.handle_response('This role does not exist', status_code=400)
 		return self.handle_response('This User has this Role already', status_code=400)
 

--- a/app/controllers/user_controller.py
+++ b/app/controllers/user_controller.py
@@ -41,10 +41,10 @@ class UserController(BaseController):
             List of admin users' profiles.
         '''
 
-        user_roles = self.user_role_repo.filter_by(role_id=admin_role_id, is_active=True).items
+        user_roles = self.user_role_repo.filter_by(role_id=admin_role_id, is_active=True)
 
         admin_users_list = []
-        for user_role in user_roles:
+        for user_role in user_roles.items:
             admin_user_profile = {}
             andela_user_profile = self.andela_service.get_user_by_email_or_id(user_role.user_id) or \
                                   self.andela_service.get_user_by_email_or_id(user_role.email)
@@ -63,7 +63,7 @@ class UserController(BaseController):
 
         return self.handle_response(
             'OK',
-            payload={'adminUsers': admin_users_list}
+            payload={'adminUsers': admin_users_list, 'meta': self.pagination_meta(user_roles)}
         )
 
     def list_all_users(self):

--- a/tests/unit/controllers/test_user_controller.py
+++ b/tests/unit/controllers/test_user_controller.py
@@ -30,12 +30,14 @@ class TestUserController(BaseTestCase):
             is_active=True
         )
 
+    @patch.object(UserController, 'pagination_meta')
     @patch('app.repositories.user_role_repo.UserRoleRepo.filter_by')
     @patch('app.services.andela.AndelaService.get_user_by_email_or_id')
     def test_list_admin_users_ok_response(
         self,
         mock_get_user_by_email_or_id,
-        mock_filter_by
+        mock_filter_by,
+        mock_pagination_meta
     ):
         '''
         Test list_admin_users OK response.
@@ -50,6 +52,13 @@ class TestUserController(BaseTestCase):
                 "last_name": "Serunjogi",
                 "name": "Joseph Serunjogi"
             }
+            mock_pagination_meta.return_value = {
+            "total_rows": 1,
+            "total_pages": 1,
+            "current_page": 1,
+            "next_page": None,
+            "prev_page": None
+        }
             user_controller = UserController(self.request_context)
 
             # Act
@@ -58,6 +67,8 @@ class TestUserController(BaseTestCase):
             # Assert
             assert result.status_code == 200
             assert result.get_json()['msg'] == 'OK'
+            assert result.get_json()['payload']['meta']['current_page'] == 1
+            assert result.get_json()['payload']['meta']['next_page'] == None
 
     @patch.object(Auth, 'get_location')
     @patch.object(UserController, 'request_params')


### PR DESCRIPTION
**What does this PR do?**
* fix get admin user endpoint to return pagination meta data

**Description of Task to be completed?**
* fix get admin user endpoint to return pagination meta data
* fix create user-role endpoint to return user name

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin bg-fix-get-admin-userendpoint-166755081 && bg-fix-get-admin-userendpoint-166755081`
* Start  the virtual environment `source venv/bin/activate`
* run tests `pytest`

**Any background context you want to provide?**
* N/A

**What are the relevant pivotal tracker stories?**
* [166755081](https://www.pivotaltracker.com/story/show/166755081)  