### PR TITLE
#167034941 Order can be collected after the order date has passed.

### DIFF
--- a/tests/unit/controllers/test_order_controller.py
+++ b/tests/unit/controllers/test_order_controller.py
@@ -712,7 +712,7 @@ class TestOrderController(BaseTestCase):
             mock_request_params.return_value = (
                 1,
                 'mock',
-                '2019-02-13'
+                '2029-02-13'
             )
             mock_order_repo_update.return_value = self.mock_order
             order_controller = OrderController(self.request_context)
@@ -723,6 +723,35 @@ class TestOrderController(BaseTestCase):
             # Assert
             assert result.status_code == 200
             assert result.get_json()['msg'] == 'Order successfully collected'
+
+    @patch('app.controllers.order_controller.OrderController.request_params')
+    @patch('app.repositories.order_repo.OrderRepo.find_first')
+    @patch('app.repositories.order_repo.OrderRepo.update')
+    def test_collect_order_past_order_date(
+        self,
+        mock_order_repo_update,
+        mock_find_first,
+        mock_request_params
+    ):
+        '''Test collect_order OK response.
+        '''
+        # Arrange
+        with self.app.app_context():
+            mock_find_first.return_value = self.mock_order
+            mock_request_params.return_value = (
+                1,
+                'mock',
+                '2019-02-13'
+            )
+            mock_order_repo_update.return_value = self.mock_order
+            order_controller = OrderController(self.request_context)
+
+            # Act
+            result = order_controller.collect_order()
+
+            # Assert
+            assert result.status_code == 400
+            assert result.get_json()['msg'] == 'Cannot collect order for past date 2019-02-13.'
 
     @patch('app.controllers.order_controller.OrderController.request_params')
     @patch('app.repositories.order_repo.OrderRepo.find_first')


### PR DESCRIPTION
**What does this PR do?**
* Handles scenario for when user attempts to collect an order for which the order date has passed

**Description of Task to be completed?**
* User should not be able to collect an order with passed order date

**How should this be manually tested?**
* Pull and checkout to this branch locally by running `git fetch origin bg-collect-order-valid-date-167034941 && git checkout bg-collect-order-valid-date-167034941`
* Start  the virtual environment `. venv/bin/activate`
* run server `flask run`
* Create an order in your local db ad give it a past order date
* In postman, hit the collect enpoint  `POST {{base-url}}/orders/collect`, with request data corresponding to the order created above
* The following response will be returned
```
{
  "msg": "Cannot collect order for past date <oder_date_used>."
}
```


**Any background context you want to provide?**
* N/A

**What are the relevant pivotal tracker stories?**
* [167034941](https://www.pivotaltracker.com/story/show/167034941)