### PR TITLE
#166788919 Get menu template items

### DIFF
--- a/app/blueprints/documentation/get_menu_template_items.yml
+++ b/app/blueprints/documentation/get_menu_template_items.yml
@@ -1,0 +1,97 @@
+Get Menu Template Items
+---
+summary: Get menu template items for particular Menu template and day
+tags:
+- Menu Template Items
+operationId: MenuTemplateItemsGet
+deprecated: false
+produces:
+- application/json
+parameters:
+- name: Content-Type
+  in: header
+  required: true
+  type: string
+- name: X-Location
+  in: header
+  required: true
+  type: string
+- name: Authorization
+  in: header
+  required: true
+  type: string
+
+responses:
+  200:
+    description: ''
+    examples:
+      application/json:
+        msg: OK
+        payload:
+          MealTemplateItems:
+          - id: 2
+            isDeleted: false
+            mainMealId: 1
+            allowedSide: 1
+            allowedProtein: 1
+            dayId: 2
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 30 Jul 2019 14:22:25 GMT
+          - id: 3
+            isDeleted: false
+            mainMealId: 1
+            allowedSide: 1
+            allowedProtein: 2
+            dayId: 1
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 30 Jul 2019 14:22:25 GMT
+          - id: 4
+            isDeleted: false
+            mainMealId: 2
+            allowedSide: 1
+            allowedProtein: 1
+            dayId: 2
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 30 Jul 2019 14:22:25 GMT
+          - id: 5
+            isDeleted: false
+            mainMealId: 1
+            allowedSide: 1
+            allowedProtein: 0
+            dayId: 2
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 31 Jul 2019 14:22:25 GMT
+          - id: 6
+            isDeleted: false
+            mainMealId: 1
+            allowedSide: 2
+            allowedProtein: 1
+            dayId: 3
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 30 Jul 2019 14:22:25 GMT
+          - id: 7
+            isDeleted: false
+            mainMealId: 1
+            allowedSide: 1
+            allowedProtein: 1
+            dayId: 2
+            timestamps:
+              created_at: 2019-07-30
+              updated_at: Tue, 20 Jul 2019 14:22:25 GMT
+          meta:
+            total_rows: 6
+            total_pages: 1
+            current_page: 1
+            next_page: 
+            prev_page: 
+    headers: {}
+  400:
+    description: BAD REQUEST
+    examples:
+      application/json:
+        msg: Authorization Header is Expected

--- a/app/blueprints/documentation/get_menu_template_items.yml
+++ b/app/blueprints/documentation/get_menu_template_items.yml
@@ -20,6 +20,10 @@ parameters:
   in: header
   required: true
   type: string
+- name: day_id
+  in: url
+  required: true
+  type: integer
 
 responses:
   200:

--- a/app/blueprints/menu_template_item_blueprint.py
+++ b/app/blueprints/menu_template_item_blueprint.py
@@ -2,6 +2,7 @@ from app.blueprints.base_blueprint import (Auth, BaseBlueprint, Blueprint,
                                            request)
 from app.controllers.menu_template_item_controller import MenuTemplateItemController
 from app.utils.security import Security
+from app.models import MenuTemplateItem
 from flasgger import swag_from
 
 url_prefix = '{}/menu_template_items'.format(BaseBlueprint.base_url_prefix)
@@ -11,13 +12,20 @@ menu_template_item_blueprint = Blueprint(
 menu_template_item_controller = MenuTemplateItemController(request)
 
 
-@menu_template_item_blueprint.route('/', methods=['POST', 'GET'])
+@menu_template_item_blueprint.route('/', methods=['POST'])
 @Auth.has_role('admin')
 @Security.validator([
     'mainMealId|required', 'allowedSide|required:int',
     'allowedProtein|required', 'sideItems|exists|meal_item|id|required',
-    'proteinItems|exists|meal_item|id|required','dayId|required'])
+    'proteinItems|exists|meal_item|id|required', 'dayId|required'])
 @swag_from('documentation/create_menu_template_item.yml', methods=['POST'])
+def create_menu_template_item():
+    return menu_template_item_controller.create()
+
+
+@menu_template_item_blueprint.route('/', methods=['GET'])
+@Security.validate_query_params(MenuTemplateItem)
+@Auth.has_role('admin')
 @swag_from('documentation/get_menu_template_items.yml', methods=['GET'])
-def create_menu_template():
-    return menu_template_item_controller.create() if request.method == 'POST' else menu_template_item_controller.get_all()
+def get_menu_template_items():
+    return menu_template_item_controller.get_all()

--- a/app/blueprints/menu_template_item_blueprint.py
+++ b/app/blueprints/menu_template_item_blueprint.py
@@ -11,12 +11,13 @@ menu_template_item_blueprint = Blueprint(
 menu_template_item_controller = MenuTemplateItemController(request)
 
 
-@menu_template_item_blueprint.route('/', methods=['POST'])
+@menu_template_item_blueprint.route('/', methods=['POST', 'GET'])
 @Auth.has_role('admin')
 @Security.validator([
     'mainMealId|required', 'allowedSide|required:int',
     'allowedProtein|required', 'sideItems|exists|meal_item|id|required',
     'proteinItems|exists|meal_item|id|required','dayId|required'])
-@swag_from('documentation/create_menu_template_item.yml')
-def create_menu_template_item():
-    return menu_template_item_controller.create()
+@swag_from('documentation/create_menu_template_item.yml', methods=['POST'])
+@swag_from('documentation/get_menu_template_items.yml', methods=['GET'])
+def create_menu_template():
+    return menu_template_item_controller.create() if request.method == 'POST' else menu_template_item_controller.get_all()

--- a/app/controllers/menu_template_item_controller.py
+++ b/app/controllers/menu_template_item_controller.py
@@ -43,3 +43,15 @@ class MenuTemplateItemController(BaseController):
         if template_item:
             return get_ids_list(template_item.side_items) == get_ids_list(side_item_objects)\
                 and get_ids_list(template_item.protein_items) == get_ids_list(protein_item_objects)
+
+    def get_all(self):
+        query_kwargs = self.get_params_dict()
+        menu_template_items = self.menu_template_item_repo.get_menu_template_items_by_day_and_menu_template(
+            query_kwargs['day_id'], query_kwargs['template_id']
+        )
+        menu_template_item_list = []
+        if menu_template_items.items:
+            menu_template_item_list = [menu_template_item.serialize()
+                                  for menu_template_item in menu_template_items.items]
+        return self.handle_response('OK', payload={'MenuTemplateItems': menu_template_item_list,
+                                                   'meta': self.pagination_meta(menu_template_items)})

--- a/app/controllers/menu_template_item_controller.py
+++ b/app/controllers/menu_template_item_controller.py
@@ -46,8 +46,8 @@ class MenuTemplateItemController(BaseController):
 
     def get_all(self):
         query_kwargs = self.get_params_dict()
-        menu_template_items = self.menu_template_item_repo.get_menu_template_items_by_day_and_menu_template(
-            query_kwargs['day_id'], query_kwargs['template_id']
+        menu_template_items = self.menu_template_item_repo.get_menu_template_items_by_day(
+            query_kwargs['day_id']
         )
         menu_template_item_list = []
         if menu_template_items.items:

--- a/app/repositories/menu_template_item_repo.py
+++ b/app/repositories/menu_template_item_repo.py
@@ -1,4 +1,4 @@
-from app.models.menu_template import MenuTemplateItem
+from app.models.menu_template import MenuTemplateItem, MenuTemplateWeekDay
 from app.repositories import BaseRepo
 
 
@@ -15,3 +15,8 @@ class MenuTemplateItemRepo(BaseRepo):
             side_items=side_items, day_id=day_id)
         menu_template_item.save()
         return menu_template_item
+
+    def get_menu_template_items_by_day_and_menu_template(self, day_id, template_id):
+        return self._model.query.filter_by(
+            day_id=day_id
+        ).join(MenuTemplateWeekDay).filter_by(template_id=template_id).paginate(error_out=False)

--- a/app/repositories/menu_template_item_repo.py
+++ b/app/repositories/menu_template_item_repo.py
@@ -16,7 +16,7 @@ class MenuTemplateItemRepo(BaseRepo):
         menu_template_item.save()
         return menu_template_item
 
-    def get_menu_template_items_by_day_and_menu_template(self, day_id, template_id):
+    def get_menu_template_items_by_day(self, day_id):
         return self._model.query.filter_by(
             day_id=day_id
-        ).join(MenuTemplateWeekDay).filter_by(template_id=template_id).paginate(error_out=False)
+        ).paginate(error_out=False)

--- a/tests/integration/endpoints/test_menu_template_items.py
+++ b/tests/integration/endpoints/test_menu_template_items.py
@@ -143,7 +143,7 @@ class TestMenuTemplateItem(BaseTestCase, BaseTestUtils):
         template.save()
         # template_id in url refers to menu template and not that created above
         response = self.client().get(
-            self.make_url("/menu_template_items?template_id=1&day_id=1"),
+            self.make_url("/menu_template_items?day_id=1"),
             headers=self.headers()
         )
         response_json = self.decode_from_json_string(
@@ -160,7 +160,7 @@ class TestMenuTemplateItem(BaseTestCase, BaseTestUtils):
             day_id=1,
         )
         response = self.client().get(
-            self.make_url(f"/menu_template_items?template_id={template.id}&day_id=1"),
+            self.make_url(f"/menu_template_items?day_id=1"),
             headers=self.headers()
         )
         response_json = self.decode_from_json_string(
@@ -179,7 +179,7 @@ class TestMenuTemplateItem(BaseTestCase, BaseTestUtils):
         )
         template.save()
         response = self.client().get(
-            self.make_url("/menu_template_items?template_id=2&day_id=1"),
+            self.make_url("/menu_template_items?day_id=4"),
             headers=self.headers()
         )
         response_json = self.decode_from_json_string(


### PR DESCRIPTION
#### What does this PR do?
- Allow the retrieval of menu template items for a particular template and day

#### Description of Task to be completed?
-  add a get function to retrieve menu_template_items for specific template and day
- add tests for implementation

#### How should this be manually tested?
- Pull and checkout to this branch locally by running `git fetch` && `git checkout ft-get-menutemplate-items-166788919`

- Run the server and go to the URL `http://127.0.0.1:5000/api/v1/menu_template_items?template_id=<id>&day_id=<id>` to get menu template items for particular template and day

- Run test `pytest -k pytest -k TestMenuTemplateItem`

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#166788919](https://www.pivotaltracker.com/story/show/166788919)