### PR TITLE
#168335901 Add name length validation on menu template

### DIFF
--- a/app/blueprints/menu_template_blueprint.py
+++ b/app/blueprints/menu_template_blueprint.py
@@ -19,7 +19,7 @@ menu_template_controller = MenuTemplateController(request)
 
 @menu_template_blueprint.route('/', methods=['POST'])
 @Auth.has_role('admin')
-@Security.validator(['name|required', 'mealPeriod|required:enum_MealPeriods', 'description|required'])
+@Security.validator(['name|required:length-50', 'mealPeriod|required:enum_MealPeriods', 'description|required:length-100'])
 @swag_from('documentation/create_menu_template.yml')
 def create_menu_template():
     return menu_template_controller.create()
@@ -35,7 +35,7 @@ def get_menu_templates():
 
 @menu_template_blueprint.route('/<int:id>', methods=['PATCH', 'PUT'])
 @Auth.has_role('admin')
-@Security.validator(['name|string', 'description|string', 'mealPeriod|enum_MealPeriods'])
+@Security.validator(['name|string:length-50', 'description|string:length-100', 'mealPeriod|enum_MealPeriods'])
 @swag_from('documentation/update_menu_template.yml')
 def update_menu_template(id):
     return menu_template_controller.update(id)

--- a/tests/integration/endpoints/test_menu_templates.py
+++ b/tests/integration/endpoints/test_menu_templates.py
@@ -2,6 +2,7 @@ from factories import (LocationFactory, MenuTemplateFactory,
                        VendorEngagementFactory, MenuTemplateItemFactory, PermissionFactory)
 from tests.base_test_case import BaseTestCase
 from tests.base_test_utils import BaseTestUtils
+import faker 
 
 
 class TestMenuTemplate(BaseTestCase, BaseTestUtils):
@@ -319,3 +320,18 @@ class TestMenuTemplate(BaseTestCase, BaseTestUtils):
         self.assertJSONKeyPresent(response.json, 'payload')
         self.assertEqual(response.json['payload'], {
             'msg': f'Start and end date should be between {engagement.start_date} and {engagement.end_date}'},)
+    
+
+    def test_create_menu_template_with_name_greater_than_50_fails(self):
+        self.create_admin()
+        LocationFactory.create(id=1).save()
+        data = {
+            "name": faker.Faker().text(150),
+            "mealPeriod": "lunch",
+            "description": "somehting"
+        }
+        response = self.client().post(
+            self.make_url("/menu_template/"), headers=self.headers(),
+            data=self.encode_to_json_string(data))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json['msg'],'Bad Request - name can only have a len of 50')


### PR DESCRIPTION
## What does this PR do
- add length validation on menu templates

#### Description of Task to be completed?
-  add length validation on menu templates

#### How should this be manually tested?
- Pull and checkout to this branch locally by running `git fetch add-length-validation-168335901 && add-length-validation-168335901`
- Run test `pytest -k pytest -k test_create_menu_template_with_name_greater_than_50_fails`
#### What are the relevant pivotal tracker stories?
- [#168335901](https://www.pivotaltracker.com/story/show/168335901)